### PR TITLE
Synchronized initiator enable/disable to avoid possible race conditions

### DIFF
--- a/cws-service/src/main/java/jpl/cws/process/initiation/InitiatorsService.java
+++ b/cws-service/src/main/java/jpl/cws/process/initiation/InitiatorsService.java
@@ -609,12 +609,13 @@ public class InitiatorsService implements InitializingBean {
 		
 	}
 	
-	
-	public void disableAndStopInitiator(String initiatorId) throws Exception {
+	// Synchronized to prevent race conditions in refreshing the spring context
+	public synchronized void disableAndStopInitiator(String initiatorId) throws Exception {
 		disableAndStopInitiator(cwsConsoleService.getProcessInitiatorById(initiatorId));
 	}
-	
-	public void enableAndStartInitiator(String initiatorId) throws Exception {
+
+	// Synchronized to prevent race conditions in refreshing the spring context
+	public synchronized void enableAndStartInitiator(String initiatorId) throws Exception {
 		enableAndStartInitiator(cwsConsoleService.getProcessInitiatorById(initiatorId));
 	}
 	


### PR DESCRIPTION
This small change should prevent the UI's "Enable All" toggle switch from causing race conditions, forcing calls to the enable / disable methods to be performed sequentially. 