### PR TITLE
Add support for whitespace in exitEventMap in the modeler

### DIFF
--- a/cws-engine-service/src/main/java/jpl/cws/engine/CwsEngineProcessApplication.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/CwsEngineProcessApplication.java
@@ -391,7 +391,7 @@ public class CwsEngineProcessApplication extends SpringServletProcessApplication
 									String successExitValues = getFieldValue(fieldName, fields, expressionManager, execution);
 									
 									fieldName = "exitCodeEvents";
-									String exitCodeEvents = getFieldValue(fieldName, fields, expressionManager, execution);
+									String exitCodeEvents = getFieldValue(fieldName, fields, expressionManager, execution).replaceAll("\\s+", "");
 									
 									fieldName = "throwOnFailures";
 									String throwOnFailures = getFieldValue(fieldName, fields, expressionManager, execution);

--- a/cws-engine-service/src/main/java/jpl/cws/engine/CwsExternalTaskThread.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/CwsExternalTaskThread.java
@@ -192,7 +192,7 @@ public class CwsExternalTaskThread extends Thread  {
 				successfulValues = (String)task.getVariables().get(fieldName);
 
 				fieldName = activityId + "_cwsExitCodeEvents";
-				String exitCodeEventsString = (String)task.getVariables().get(fieldName);
+				String exitCodeEventsString = ((String)task.getVariables().get(fieldName)).replaceAll("\\s+", "");
 
 				exitCodeEventsMap.clear();
 				String[] exitCodeMapArray = exitCodeEventsString.split(",");


### PR DESCRIPTION
Resolves #8 

Simple change to clear all whitespace from user input before being parsed as a string in comma-separated key=value format. The input string was already (incorrectly) assumed to be free of whitespace in the code that handled user input, so no other change is needed.

Tested with the following input in the modeler:
![Screen Shot 2021-01-04 at 3 40 59 PM](https://user-images.githubusercontent.com/11336081/103590650-3faefb00-4ea3-11eb-90c9-ef63d3887f36.png)

Logs showing a successful parse:
![Screen Shot 2021-01-04 at 3 41 27 PM](https://user-images.githubusercontent.com/11336081/103590678-50f80780-4ea3-11eb-8fcf-d7d9fc9fdd6d.png)
