### PR TITLE
Add 403 (Forbidden) to list of error codes that redirect to the CWS login page

### DIFF
--- a/install/tomcat_conf/web.xml
+++ b/install/tomcat_conf/web.xml
@@ -498,6 +498,10 @@
 		<error-code>401</error-code>
 		<location>/not_authenticated.html</location>
 	</error-page>
+    <error-page>
+        <error-code>403</error-code>
+        <location>/not_authenticated.html</location>
+    </error-page>
 	
   <!-- A filter that sets various security related HTTP Response headers.   -->
   <!-- This filter supports the following initialization parameters         -->


### PR DESCRIPTION
Pretty simple change, 403 wasn't getting caught. We were only redirecting on 401 (unauthorized) when Camunda's apps return 403 (forbidden) when not logged in. A change to the main Tomcat config fixes that.

Can verify by running a local build & navigating to `/camunda/app/cockpit/default/#/dashboard`, it will redirect first to `not_authorized.html` then to `cws-ui/login`.