### PR TITLE
Update Commons Compress to latest version (1.18 -> 1.20)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<!-- <boon.version>0.12</boon.version> -->
 		<camunda.version>7.13.0</camunda.version>
 		<camunda-spin.version>1.9.0</camunda-spin.version>
-		<commons-compress.version>1.5</commons-compress.version>
+		<commons-compress.version>1.20</commons-compress.version>
 		<commons-configuration.version>1.10</commons-configuration.version>
 		<commons-exec.version>1.3</commons-exec.version>
 		<commons-fileupload.version>1.3.1</commons-fileupload.version>


### PR DESCRIPTION
Resolves CVE-2019-12402 reported by dependabot. Requires v1.19 or greater.

Commons Compress is used solely in [UnzipUtility.java](https://github.com/NASA-AMMOS/common-workflow-service/blob/main/cws-installer/src/main/java/jpl/cws/task/UnzipUtility.java), which is used twice in the installer to extract zip archives. 

Tested by running the installer and verifying that the archives were properly unpacked. 

Closes #12.