### PR TITLE
Sanitize login redirect targets

### DIFF
--- a/cws-service/src/main/java/jpl/cws/controller/MvcService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/MvcService.java
@@ -101,18 +101,18 @@ public class MvcService extends MvcCore {
 				.singleResult();
 		log.debug("user: " + user);
 		
-		String pattern =							// first part: some/relative/path
-			  "^"									// Anchor at the beginning of the string
-			+ "(?!\\/)"								// Assert the first character isn't a '/' (negative lookahead)
-			+ "(?!.*\\/\\/)"						// Assert there are no "//" present anywhere (negative lookahead)
-			+ "[A-Za-z0-9-\\/]+"					// Match one or more allowed characters
-			+ "(?<!\\/)"							// Assert the last character isn't a '/'
-													// second part: ?key=value
-			+ "(\\?"								// Match '?' (start capture group 1)
-			+   "[A-Za-z0-9-]+=[A-Za-z0-9-]+"		// Match key=value format one or more times
+		String pattern =                            // first part: some/relative/path
+			  "^"                                   // Anchor at the beginning of the string
+			+ "(?!\\/)"                             // Assert the first character isn't a '/' (negative lookahead)
+			+ "(?!.*\\/\\/)"                        // Assert there are no "//" present anywhere (negative lookahead)
+			+ "[A-Za-z0-9-\\/]+"                    // Match one or more allowed characters
+			+ "(?<!\\/)"                            // Assert the last character isn't a '/'
+			                                        // second part: ?key=value
+			+ "(\\?"                                // Match '?' (start capture group 1)
+			+   "[A-Za-z0-9-]+=[A-Za-z0-9-]+"       // Match key=value format one or more times
 			+     "(&[A-Za-z0-9-]+=[A-Za-z0-9-]+)*" // Followed by &key=value zero or more times
-			+   "){0,1}"							// Match capture group 1 zero or 1 times
-			+ "$";									// Anchor at the end of the string
+			+   "){0,1}"                            // Match capture group 1 zero or 1 times
+			+ "$";                                  // Anchor at the end of the string
 
 		// if target page is not null, then redirect to target page
 		//

--- a/cws-service/src/main/java/jpl/cws/controller/MvcService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/MvcService.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -99,9 +101,33 @@ public class MvcService extends MvcCore {
 				.singleResult();
 		log.debug("user: " + user);
 		
+		String pattern =							// first part: some/relative/path
+			  "^"									// Anchor at the beginning of the string
+			+ "(?!\\/)"								// Assert the first character isn't a '/' (negative lookahead)
+			+ "(?!.*\\/\\/)"						// Assert there are no "//" present anywhere (negative lookahead)
+			+ "[A-Za-z0-9-\\/]+"					// Match one or more allowed characters
+			+ "(?<!\\/)"							// Assert the last character isn't a '/'
+													// second part: ?key=value
+			+ "(\\?"								// Match '?' (start capture group 1)
+			+   "[A-Za-z0-9-]+=[A-Za-z0-9-]+"		// Match key=value format one or more times
+			+     "(&[A-Za-z0-9-]+=[A-Za-z0-9-]+)*" // Followed by &key=value zero or more times
+			+   "){0,1}"							// Match capture group 1 zero or 1 times
+			+ "$";									// Anchor at the end of the string
+
 		// if target page is not null, then redirect to target page
 		//
 		if (targetPage != null) {
+
+			// input validation for targetPage - make sure only relative paths with query params are allowed
+			Pattern p = Pattern.compile(pattern);
+			Matcher m = p.matcher(targetPage);
+
+			if (!m.find()) {
+				// inavalid redirect, redirect to home instead
+				log.warn("invalid redirect target at login (targetPage = " + targetPage + "), routing to home instead. was this a phishing attempt?");
+				return buildHomeModel("Welcome " + (user == null ? username : user.getFirstName()));
+			}
+
 			try {
 				log.debug("redirecting successful login (of user '" + username + "') to " + targetPage);
 				response.sendRedirect(targetPage);


### PR DESCRIPTION
New regex sanitation on login redirect targets allows for originally intended behavior of specifying a relative redirect target to be loaded for the user after a successful login. 

Allowable redirect targets are all relative paths (no leading or trailing slashes) with or without query parameter lists (`?key=value&another=someting`). Due to constraints on URL spec, further parameters in the redirect must use `%26` instead of the literal `&`, lest the parameter not make it through to the `target` variable.

Redirects are performed in the form:

```
<cws_host>/cws-ui/login?target=some/relative/path?key1=value1%26key2=value2
```

In the event of an invalid (/malformed) redirect attempt, the application will route to CWS home and the following log will be emitted:

```
invalid redirect target at login (targetPage = <the invalid redirect>), routing to home instead. was this a phishing attempt?
```