### PR TITLE
Tune db connection pool to more diligently reap idle and abandoned connections

### DIFF
--- a/install/tomcat_conf/server.xml
+++ b/install/tomcat_conf/server.xml
@@ -73,6 +73,11 @@
               validationQuery="SELECT 1"
               validationInterval="30000"
               logValidationErrors="true"
+
+              timeBetweenEvictionRunsMillis="30000"
+              minEvictableIdleTimeMillis="60000"
+              removeAbandoned="true"
+              removeAbandonedTimeout="120"
               
               testOnBorrow="true"
               testWhileIdle="true"


### PR DESCRIPTION
This should address potential memory leaks in workers' connection pools. According to [the Tomcat docs](https://tomcat.apache.org/tomcat-9.0-doc/jdbc-pool.html), these changes to the connection pool should have the following behavior:

Every 30 seconds, an eviction check will be run. Threads that have been idle for more than 60 seconds are eligible for eviction, should they fail validation. 

Connections that are considered abandoned will be removed. A connection that has been borrowed for more than 2 minutes without being returned is assumed abandoned and is closed. _CWS previously only logged such occurrences._ 

> **NOTE**: `removeAbandonedTimeout` should be at least as long as the longest query we expect to run in CWS. In the past, this was the console summary statistics, which could run for much longer than 2 minutes. This has since been remedied, leaving 2 minutes as a _generous_ timeout on connections borrowed from the connection pool.