### PR TITLE
reworked worker claim strategy

### DIFF
--- a/cws-core/src/main/java/jpl/cws/core/db/SchedulerDbService.java
+++ b/cws-core/src/main/java/jpl/cws/core/db/SchedulerDbService.java
@@ -247,89 +247,92 @@ public class SchedulerDbService extends DbService implements InitializingBean {
 	/**
 	 * Attempt to claim a process start request in the database.
 	 * 
-	 * @param limitToTheseProcessDefs -- if specified, only attempt to claim these types of process defs
-	 * @return number of rows claimed
+	 * @param procDefKey -- only attempt to claim rows for this process definition
+	 * @return mappings of claimUuids and claimedRowUuids
+	 *
 	 */
-	public Map<String,List<String>> claimHighestPriorityStartReq(String workerId, List<String> limitToTheseProcessDefs, String procDefKey, int limit) {
+	public Map<String,List<String>> claimHighestPriorityStartReq(String workerId, String procDefKey, int limit) {
 		List<String> claimUuids = new ArrayList<String>();
 		List<String> rowUuids = new ArrayList<String>();
 		List<String> claimedRowUuids = new ArrayList<String>();
 		long t0 = System.currentTimeMillis();
-		int numUpdated = 0;
+		int numClaimed = 0;
 		String claimUuid = null;
-		if (procDefKey == null) {
-			log.error("procDefKey is null!! code should not reach here");
-		}
-		else {
-			// Try to update, until we succeed.
-			//
-			int attempts = 0;
-			
-			while (attempts++ < 10) {
-				// ---------------------------------
-				// SELECT then UPDATE methodology
-				// ---------------------------------
-				try {
-					// SELECT CANDIDATE ROWS
-					//
-					rowUuids = jdbcTemplate.queryForList(
-							FIND_CLAIMABLE_ROWS_SQL, String.class,
-							new Object[] {procDefKey, limit});
-					
-					if (!rowUuids.isEmpty()) {
-						// Iterate over candidates, trying to update them
-						//
-						for (String uuid : rowUuids) {
-							claimUuid = UUID.randomUUID().toString();
-							int updateCount = jdbcTemplate.update(UPDATE_CLAIMABLE_ROW_SQL,
-									new Object[] {workerId, claimUuid, uuid, workerId});
-							
-							// FIXME:  IS THERE A WAY TO MAKE THIS DO BATCH UPDATES, INSTEAD OF ONE AT A TIME??
+		int attempts = 0;
 
-							if (updateCount == 1) {
-								numUpdated++;
-								claimUuids.add(claimUuid);
-								claimedRowUuids.add(uuid);
-								log.debug("CLAIMED " + claimUuid + " (uuid=" +uuid+")");
-							}
-							//else {
-							//	log.info("DID NOT CLAIM " + claimUuid + " (uuid=" +uuid+")");
-							//}
+		// Try, until succeeding in claiming at least one row
+		//
+		while (attempts++ < 10) {
+			try {
+				// Find claimable rows
+				//
+				rowUuids = jdbcTemplate.queryForList(
+						FIND_CLAIMABLE_ROWS_SQL, String.class,
+						new Object[] {procDefKey,
+								limit*2}); // over-find because some workers might compete with this set
+
+				if (!rowUuids.isEmpty()) {
+					// Found some claimable rows, so now try to claim them..
+					//
+					for (String uuid : rowUuids) {
+						claimUuid = UUID.randomUUID().toString();
+						int updateCount = jdbcTemplate.update(UPDATE_CLAIMABLE_ROW_SQL,
+								new Object[] {workerId, claimUuid, uuid, workerId});
+
+						if (updateCount == 1) {
+							numClaimed++;
+							claimUuids.add(claimUuid);
+							claimedRowUuids.add(uuid);
+							log.debug("CLAIMED " + claimUuid + " (uuid=" +uuid+") for procDefKey '" + procDefKey + "'");
 						}
-						//log.debug("updated " + numUpdated + " / " + rowUuids.size());
+
+						if (numClaimed == limit) {
+							break; // we have claimed up to the limit, so stop claiming
+						}
 					}
-					else if (log.isTraceEnabled()) {
-						log.trace("NO CLAIMABLE CANDIDATES AT THIS TIME");
+
+					if (numClaimed == 0) {
+						// other workers beat us to claiming the rows
+						log.warn("Attempted to claim " + rowUuids.size() + " rows for procDefKey '" + procDefKey + "', but claimed none! " +
+								(attempts < 10 ? "Retrying..." : "GIVING UP!"));
+						continue; // retry finding claimable rows
 					}
-					
-					break; // no retry needed
-				}
-				catch (DeadlockLoserDataAccessException e) {
-					if (attempts == 10) {
-						log.error("Caught a DeadlockLoserDataAccessException.  NOT Retyring as 10 attempts have been tried already!..");
-						break; // give up
+					else {
+						log.debug("Claimed (" + numClaimed + " of " + rowUuids.size() + ") for procDefKey '" + procDefKey + "'");
 					}
-					log.warn("Caught a DeadlockLoserDataAccessException.  Retrying..");
-					continue; // retry
 				}
-				catch (Throwable t) {
-					log.error("Unexpected exception.  Not retrying..", t);
-					break; // abort
+				else if (log.isTraceEnabled()) {
+					log.trace("NO CLAIMABLE CANDIDATES AT THIS TIME");
 				}
-			} // end while (attempts)
-		}
+
+				break; // no retry needed
+			}
+			catch (DeadlockLoserDataAccessException e) {
+				if (attempts == 10) {
+					log.error("Caught a DeadlockLoserDataAccessException.  NOT Retrying as 10 attempts have been tried already!..");
+					break; // give up
+				}
+				log.warn("Caught a DeadlockLoserDataAccessException.  Retrying..");
+				continue; // retry
+			}
+			catch (Throwable t) {
+				log.error("Unexpected exception.  Not retrying..", t);
+				break; // abort
+			}
+		} // end while (attempts)
+
 		long timeTaken = System.currentTimeMillis() - t0;
 		if (timeTaken > SLOW_WARN_THRESHOLD) {
 			log.warn("CLAIM cws_sched_worker_proc_inst took " + timeTaken + " ms!");
 		}
-		if (numUpdated >= 1) {
-			log.info("worker " + workerId + " claimed " + numUpdated + " row(s).");
+		if (numClaimed >= 1) {
+			log.info("worker " + workerId + " claimed " + numClaimed + " row(s).");
 		}
 		else {
 			log.trace("no rows claimed by worker: " + workerId);
 		}
 		
-		if (numUpdated != claimUuids.size()) {
+		if (numClaimed != claimUuids.size()) {
 			log.error("numUpdated != claimUuids.size()" );
 		}
 		
@@ -381,7 +384,6 @@ public class SchedulerDbService extends DbService implements InitializingBean {
 		List<Map<String,Object>> list = jdbcTemplate.queryForList(
 			"SELECT * FROM cws_sched_worker_proc_inst " +
 			"WHERE claim_uuid IN (" + claimUuidsStr + ")");
-			//new Object[] {claimUuid});
 		long timeTaken = System.currentTimeMillis() - t0;
 		if (timeTaken > SLOW_WARN_THRESHOLD) {
 			log.warn("SELECT * FROM cws_sched_worker_proc_inst by claim_uuid took " + timeTaken + " ms!");

--- a/cws-engine-service/src/main/java/jpl/cws/engine/WorkerService.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/WorkerService.java
@@ -693,7 +693,7 @@ public class WorkerService implements InitializingBean {
 					// claim for remainder (marks DB rows as "claimedByWorker")
 					Map<String,List<String>> claimRowData = 
 						schedulerDbService.claimHighestPriorityStartReq(
-							workerId, null, procDefKey, queryLimit);
+							workerId, procDefKey, queryLimit);
 					
 					List<String> claimed = claimRowData.get("claimUuids");
 					
@@ -707,7 +707,7 @@ public class WorkerService implements InitializingBean {
 						procStartReqUuidStartedThisWorker.addAll(claimRowData.get("claimedRowUuids"));
 						//log.debug("procStartReqUuidStartedThisWorker = " + procStartReqUuidStartedThisWorker);
 						
-						log.debug("(CLAIMED " + claimed.size() + " / " + queryLimit + ", max=" + procMaxNumber + ")  for procDef '" + procDefKey + "' (limitToProcDefKey="+limitToProcDefKey+")");
+						log.debug("(CLAIMED " + claimed.size() + " / " + queryLimit + ", maxProcs=" + procMaxNumber + ")  for procDef '" + procDefKey + "' (limitToProcDefKey="+limitToProcDefKey+")");
 						
 						claimUuids.addAll(claimed);
 					}

--- a/cws-engine-service/src/main/java/jpl/cws/engine/listener/ProcessStartReqProcessor.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/listener/ProcessStartReqProcessor.java
@@ -50,11 +50,11 @@ public class ProcessStartReqProcessor implements Runnable {
 		
 		log.trace("ProcessStartReqProcessor run()...");
 		try {
-			// Sleep for a random amount (up to a second).
+			// Sleep for a random amount (up to a quarter second).
 			// This is to avoid all workers hitting the database at the exact same time
 			// when a process request (topic) comes in.
 			//
-			//Thread.sleep((long)(Math.random() * 1000.0));
+			Thread.sleep((long)(Math.random() * 250.0));
 			
 			// Attempt to claim a start request
 			//

--- a/cws-service/src/main/java/jpl/cws/process/initiation/aws/SQSDispatcherThread.java
+++ b/cws-service/src/main/java/jpl/cws/process/initiation/aws/SQSDispatcherThread.java
@@ -368,7 +368,7 @@ public class SQSDispatcherThread extends Thread implements InitializingBean {
 			log.debug("AWS credentials / client refreshed.");
 		}
 		else {
-            log.debug("Refresh of AWS SQS client not necessary.");
+            log.trace("Refresh of AWS SQS client not necessary.");
         }
 	}
 	


### PR DESCRIPTION
1) better, more thorough logging
 2a) retry logic on workers when they have an "empty" claim session (when other workers beat them to the rows).
 2b) also reworked the claim logic slightly, so that workers will over-find claimable rows, then iterate through claimable up to their limit.  This should reduce "empty" claim sessions
  (see bottom of email for new method logic)
2c) Cleaned up and simplified claim code overall