### PR TITLE
Switch connection pool from Tomcat to HikariCP

### DIFF
--- a/create_server_dist.sh
+++ b/create_server_dist.sh
@@ -110,6 +110,7 @@ rm -rf ${CWS_TOMCAT_ROOT}/webapps/docs
 print 'Installing DB drivers to Tomcat...'
 cp ${ROOT}/cws-installer/cws-installer-libs/mysql-connector-java-*.jar ${TOMCAT_LIB_DIR}
 cp ${ROOT}/cws-installer/cws-installer-libs/mariadb-java-client-*.jar  ${TOMCAT_LIB_DIR}
+cp ${ROOT}/cws-installer/cws-installer-libs/HikariCP-*.jar             ${TOMCAT_LIB_DIR}
 
 print 'Installing core libraries to Tomcat...'
 cp ${ROOT}/cws-core/target/cws-core.jar                     ${TOMCAT_LIB_DIR}

--- a/cws-adaptation-engine/pom.xml
+++ b/cws-adaptation-engine/pom.xml
@@ -89,7 +89,13 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
-		
+
+		<!-- HikariCP database connection pool -->
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+		</dependency>
+
 		<!-- Spring MVC framework -->
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/cws-engine-service/pom.xml
+++ b/cws-engine-service/pom.xml
@@ -191,6 +191,12 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
+
+		<!-- HikariCP database connection pool -->
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+		</dependency>
 		
 		<!-- Spring MVC framework -->
 		<dependency>

--- a/cws-installer/pom.xml
+++ b/cws-installer/pom.xml
@@ -67,6 +67,12 @@
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
+
+		<!-- HikariCP database connection pool -->
+		<dependency>
+			<groupId>com.zaxxer</groupId>
+			<artifactId>HikariCP</artifactId>
+		</dependency>
 		
 		<dependency>
 			<groupId>junit</groupId>

--- a/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
+++ b/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
@@ -2026,13 +2026,6 @@ public class CwsInstaller {
 		content = content.replace("__CWS_SHUTDOWN_PORT__",         cws_shutdown_port);
 		content = content.replace("__CWS_TOMCAT_CONF_DIR__",       cws_tomcat_conf);
 
-		if (cws_worker_type.equals("run_external_tasks_only")) {
-			content = content.replace("__CWS_DB_NUM_CONNECTIONS__", "2");
-		}
-		else {
-			content = content.replace("__CWS_DB_NUM_CONNECTIONS__", "1");
-		}
-
 		writeToFile(filePath, content);
 		copy(
 			Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "server.xml"),

--- a/cws-service/pom.xml
+++ b/cws-service/pom.xml
@@ -126,6 +126,12 @@
 					<artifactId>mysql-connector-java</artifactId>
 				</dependency>
 
+				<!-- HikariCP database connection pool -->
+				<dependency>
+					<groupId>com.zaxxer</groupId>
+					<artifactId>HikariCP</artifactId>
+				</dependency>
+
 				<dependency>
 					<groupId>commons-fileupload</groupId>
 					<artifactId>commons-fileupload</artifactId>

--- a/install/tomcat_conf/server.xml
+++ b/install/tomcat_conf/server.xml
@@ -49,76 +49,37 @@
               factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
               pathname="conf/tomcat-users.xml" />
 
-    <!-- Additional properties can be set to avoid a common exception
-         regarding connection timeout in the connection pool:
-          testOnBorrow="true"
-          validationQuery="SELECT 1"
-    -->
     <Resource name="jdbc/ProcessEngine"
               auth="Container"
               type="javax.sql.DataSource"
-              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
-              uniqueResourceName="process-engine"
+              factory="com.zaxxer.hikari.HikariJNDIFactory"
+              poolName="camunda-pool"
+
+              maximumPoolSize="10"
+              connectionTimeout="300000"
+
               driverClassName="__CWS_DB_DRIVER__"
-              url="__CWS_DB_URL__"
+              jdbcUrl="__CWS_DB_URL__"
               username="__CWS_DB_USERNAME__"
               password="__CWS_DB_PASSWORD__"
-              
-              initialSize="__CWS_DB_NUM_CONNECTIONS__"
-              minIdle="__CWS_DB_NUM_CONNECTIONS__"
-              
-              maxIdle="20"
-              maxActive="20"
-              
-              validationQuery="SELECT 1"
-              validationInterval="30000"
-              logValidationErrors="true"
 
-              timeBetweenEvictionRunsMillis="30000"
-              minEvictableIdleTimeMillis="60000"
-              removeAbandoned="true"
-              removeAbandonedTimeout="900"
-              
-              testOnBorrow="true"
-              testWhileIdle="true"
-              testOnReturn="true"
-
-              logAbandoned="true"
-
-              defaultTransactionIsolation="READ_COMMITTED" />
+              transactionIsolation="TRANSACTION_READ_COMMITTED" />
 
     <Resource name="jdbc/cws"
               auth="Container"
               type="javax.sql.DataSource"
-              factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
-              uniqueResourceName="process-engine"
+              factory="com.zaxxer.hikari.HikariJNDIFactory"
+              poolName="cws-pool"
+
+              maximumPoolSize="10"
+              connectionTimeout="300000"
+
               driverClassName="__CWS_DB_DRIVER__"
-              url="__CWS_DB_URL__"
+              jdbcUrl="__CWS_DB_URL__"
               username="__CWS_DB_USERNAME__"
               password="__CWS_DB_PASSWORD__"
 
-              initialSize="__CWS_DB_NUM_CONNECTIONS__"
-              minIdle="__CWS_DB_NUM_CONNECTIONS__"
-
-              maxIdle="20"
-              maxActive="20"
-
-              validationQuery="SELECT 1"
-              validationInterval="30000"
-              logValidationErrors="true"
-
-              timeBetweenEvictionRunsMillis="30000"
-              minEvictableIdleTimeMillis="60000"
-              removeAbandoned="true"
-              removeAbandonedTimeout="900"
-
-              testOnBorrow="true"
-              testWhileIdle="true"
-              testOnReturn="true"
-
-              logAbandoned="true"
-
-              defaultTransactionIsolation="READ_COMMITTED" />
+              transactionIsolation="TRANSACTION_READ_COMMITTED" />
 
     <Resource name="global/camunda-bpm-platform/process-engine/ProcessEngineService!org.camunda.bpm.ProcessEngineService" auth="Container"
               type="org.camunda.bpm.ProcessEngineService"

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
 		<mockito.version>1.9.5</mockito.version>
 		<mybatis.version>3.5.3</mybatis.version>
 		<mysql-connector.version>8.0.16</mysql-connector.version>
+		<hikaricp.version>4.0.3</hikaricp.version>
 		<phantomjsdriver.version>1.0.4</phantomjsdriver.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<quartz.version>2.3.2</quartz.version>
@@ -286,6 +287,19 @@
 				<groupId>mysql</groupId>
 				<artifactId>mysql-connector-java</artifactId>
 				<version>${mysql-connector.version}</version>
+			</dependency>
+
+			<!-- HikariCP database connection pool -->
+			<dependency>
+				<groupId>com.zaxxer</groupId>
+				<artifactId>HikariCP</artifactId>
+				<version>${hikaricp.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-api</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<!-- Apache Commons -->


### PR DESCRIPTION
Changes our connection pool(s) from Tomcat's default JDBC pool to the Camunda-recommended [HikariCP](https://github.com/brettwooldridge/HikariCP). This should improve performance and reduce configuration complexity. 

Namely, we're no longer tuning connection reaping, min/max waits for abandoned threads, using custom liveness probes & intervals, etc. This should hopefully tie up any loose ends on misconfigurations and overall increase database stability and performance.

Closes #41.