### PR TITLE
ElasticSearch SSL w/o Auth

### DIFF
--- a/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
+++ b/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
@@ -2533,7 +2533,7 @@ public class CwsInstaller {
 		setPreset("elasticsearch_port", elasticsearch_port);
 		setPreset("elasticsearch_use_auth", elasticsearch_use_auth);
 		setPreset("elasticsearch_username", elasticsearch_username);
-		setPreset("elasticsearcH_password", elasticsearch_password);
+		setPreset("elasticsearch_password", elasticsearch_password);
 		setPreset("user_provided_logstash", user_provided_logstash);
 		setPreset("history_level", history_level);
 		setPreset("history_days_to_live", history_days_to_live);

--- a/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
+++ b/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
@@ -721,10 +721,10 @@ public class CwsInstaller {
 			} else {
 				if (cws_auth_scheme.equalsIgnoreCase("LDAP")) {
 					cws_user = readLine("Enter name of LDAP user to be used as initial administrator. " +
-									"Default is " + cws_user + ": ", cws_user);
+							"Default is " + cws_user + ": ", cws_user);
 				} else {
 					cws_user = readLine("Enter username to be used as initial administrator. " +
-									"Default is " + cws_user + ": ", cws_user);
+							"Default is " + cws_user + ": ", cws_user);
 				}
 			}
 		} else {
@@ -795,7 +795,7 @@ public class CwsInstaller {
 						"Must specify at least one email address!");
 			} else {
 				cws_notification_emails = readLine("Enter email addresses used to notify of system errors. " +
-								"Default is " + cws_notification_emails + ": ", cws_notification_emails);
+						"Default is " + cws_notification_emails + ": ", cws_notification_emails);
 			}
 		} else {
 			if (cws_notification_emails == null) {
@@ -1030,23 +1030,22 @@ public class CwsInstaller {
 
 		// PROMPT USER FOR ELASTICSEARCH HOST
 		elasticsearch_host = getPreset("elasticsearch_host");
-		String read_elasticsearch_host = "";
 
 		if (cws_installer_mode.equals("interactive")) {
 			if (elasticsearch_host == null) {
 
+				String read_elasticsearch_host = "";
+
 				while (!read_elasticsearch_host.startsWith("https://") &&
 						!read_elasticsearch_host.startsWith("http://")) {
-
-					elasticsearch_host = readRequiredLine("Enter the Elasticsearch host (be sure to include protocol in URL: http:// or https://): ",
+					read_elasticsearch_host = readRequiredLine("Enter the Elasticsearch host (be sure to include protocol in URL: http:// or https://):  ",
 							"You must enter a hostname");
 				}
+
+
 			} else {
-				while (!read_elasticsearch_host.startsWith("https://") &&
-						!read_elasticsearch_host.startsWith("http://")) {
-					elasticsearch_host = readLine("Enter the Elasticsearch host. " +
-							"Default is " + elasticsearch_host + ": ", elasticsearch_host);
-				}
+				elasticsearch_host = readLine("Enter the Elasticsearch host. " +
+						"Default is " + elasticsearch_host + ": ", elasticsearch_host);
 			}
 		} else {
 			if (elasticsearch_host == null) {
@@ -1240,7 +1239,7 @@ public class CwsInstaller {
 
 		if (cws_installer_mode.equals("interactive")) {
 			cws_brand_header = readLine("Enter the brand header text that will display at the top of the web console. " +
-							"Default is \"" + cws_brand_header + "\": ", cws_brand_header);
+					"Default is \"" + cws_brand_header + "\": ", cws_brand_header);
 		}
 	}
 
@@ -1874,8 +1873,8 @@ public class CwsInstaller {
 			while ((process = input.readLine()) != null) {
 				//System.out.println(line);
 				if (process.contains("ntpd") ||
-					process.contains("chronyd") ||
-					process.contains("usr/libexec/timed")) {
+						process.contains("chronyd") ||
+						process.contains("usr/libexec/timed")) {
 					print("   [OK]");
 					print("");
 					return 0; // no warnings
@@ -1996,8 +1995,8 @@ public class CwsInstaller {
 		content = content.replace("__CWS_AUTH_SCHEME__",       cws_auth_scheme);
 		writeToFile(filePath, content);
 		copy(
-			Paths.get(config_work_dir + SEP + "refresh_cws_token.sh"),
-			Paths.get(cws_root + SEP + "refresh_cws_token.sh"));
+				Paths.get(config_work_dir + SEP + "refresh_cws_token.sh"),
+				Paths.get(cws_root + SEP + "refresh_cws_token.sh"));
 
 		if (installConsole) {
 			updateCwsUiConfig();
@@ -2012,19 +2011,19 @@ public class CwsInstaller {
 		content = content.replace("__CWS_CONSOLE_SSL_PORT__", cws_console_ssl_port);
 		writeToFile(filePath, content);
 		copy(
-			Paths.get(config_work_dir + SEP + "stop_cws.sh"),
-			Paths.get(cws_root + SEP + "stop_cws.sh"));
+				Paths.get(config_work_dir + SEP + "stop_cws.sh"),
+				Paths.get(cws_root + SEP + "stop_cws.sh"));
 
 		// UPDATE bpm-platform.xml
 		//
 		copy(
-			Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "bpm-platform.xml"),
-			Paths.get(cws_tomcat_root + SEP + "conf" + SEP + "bpm-platform.xml"));
+				Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "bpm-platform.xml"),
+				Paths.get(cws_tomcat_root + SEP + "conf" + SEP + "bpm-platform.xml"));
 
 		// COPY css-jaas.cfg to tomcat/lib
 		copy(
-			Paths.get(config_work_dir + SEP + "tomcat_lib" + SEP + "css-jaas.cfg"),
-			Paths.get(cws_tomcat_root + SEP + "lib" + SEP + "css-jaas.cfg"));
+				Paths.get(config_work_dir + SEP + "tomcat_lib" + SEP + "css-jaas.cfg"),
+				Paths.get(cws_tomcat_root + SEP + "lib" + SEP + "css-jaas.cfg"));
 
 		// UPDATE server.xml
 		print(" Updating server.xml (to point to CWS database)...");
@@ -2042,8 +2041,8 @@ public class CwsInstaller {
 
 		writeToFile(filePath, content);
 		copy(
-			Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "server.xml"),
-			Paths.get(cws_tomcat_root + SEP + "conf"        + SEP + "server.xml"));
+				Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "server.xml"),
+				Paths.get(cws_tomcat_root + SEP + "conf"        + SEP + "server.xml"));
 
 		updateWorkerAppContext();
 		updateWorkerProperties();
@@ -2319,7 +2318,7 @@ public class CwsInstaller {
 		writeToFile(path, content);
 
 		copy(path,
-			Paths.get(cws_tomcat_webapps + SEP + "cws-ui" + SEP + "WEB-INF" + SEP + "applicationContext.xml"));
+				Paths.get(cws_tomcat_webapps + SEP + "cws-ui" + SEP + "WEB-INF" + SEP + "applicationContext.xml"));
 
 
 		// Update clean_es_history.sh file
@@ -2377,9 +2376,9 @@ public class CwsInstaller {
 			Path indexHtml = Paths.get(cws_tomcat_webapps + SEP + cws_project_webapp_root + SEP + "index.html");
 			writeToFile(indexHtml,
 					"<html><head><meta http-equiv=\"refresh\" content=\"10;url=/cws-ui/\" /></head>" +
-					"<body>You have configured CWS to have a project web page.\n" +
-					"Put your custom content here by editing the '" + indexHtml + "' file...<br/><br/><hr/>" +
-					"Automatically redirecting to <a href=\"/cws-ui\">CWS Home</a> in 10 seconds...</body></html>");
+							"<body>You have configured CWS to have a project web page.\n" +
+							"Put your custom content here by editing the '" + indexHtml + "' file...<br/><br/><hr/>" +
+							"Automatically redirecting to <a href=\"/cws-ui\">CWS Home</a> in 10 seconds...</body></html>");
 		}
 	}
 
@@ -2490,8 +2489,8 @@ public class CwsInstaller {
 
 		print(" Put logstash conf file into place.");
 		copy(
-			Paths.get(config_work_dir + SEP + "logging" + SEP + "cws-logstash.conf"),
-			Paths.get(logstash_root   + SEP + "cws-logstash.conf"));
+				Paths.get(config_work_dir + SEP + "logging" + SEP + "cws-logstash.conf"),
+				Paths.get(logstash_root   + SEP + "cws-logstash.conf"));
 	}
 
 	private static void writeOutConfigurationFile() {

--- a/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
+++ b/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
@@ -721,10 +721,10 @@ public class CwsInstaller {
 			} else {
 				if (cws_auth_scheme.equalsIgnoreCase("LDAP")) {
 					cws_user = readLine("Enter name of LDAP user to be used as initial administrator. " +
-							"Default is " + cws_user + ": ", cws_user);
+									"Default is " + cws_user + ": ", cws_user);
 				} else {
 					cws_user = readLine("Enter username to be used as initial administrator. " +
-							"Default is " + cws_user + ": ", cws_user);
+									"Default is " + cws_user + ": ", cws_user);
 				}
 			}
 		} else {
@@ -795,7 +795,7 @@ public class CwsInstaller {
 						"Must specify at least one email address!");
 			} else {
 				cws_notification_emails = readLine("Enter email addresses used to notify of system errors. " +
-						"Default is " + cws_notification_emails + ": ", cws_notification_emails);
+								"Default is " + cws_notification_emails + ": ", cws_notification_emails);
 			}
 		} else {
 			if (cws_notification_emails == null) {
@@ -1240,7 +1240,7 @@ public class CwsInstaller {
 
 		if (cws_installer_mode.equals("interactive")) {
 			cws_brand_header = readLine("Enter the brand header text that will display at the top of the web console. " +
-					"Default is \"" + cws_brand_header + "\": ", cws_brand_header);
+							"Default is \"" + cws_brand_header + "\": ", cws_brand_header);
 		}
 	}
 
@@ -1874,8 +1874,8 @@ public class CwsInstaller {
 			while ((process = input.readLine()) != null) {
 				//System.out.println(line);
 				if (process.contains("ntpd") ||
-						process.contains("chronyd") ||
-						process.contains("usr/libexec/timed")) {
+					process.contains("chronyd") ||
+					process.contains("usr/libexec/timed")) {
 					print("   [OK]");
 					print("");
 					return 0; // no warnings
@@ -1996,8 +1996,8 @@ public class CwsInstaller {
 		content = content.replace("__CWS_AUTH_SCHEME__",       cws_auth_scheme);
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "refresh_cws_token.sh"),
-				Paths.get(cws_root + SEP + "refresh_cws_token.sh"));
+			Paths.get(config_work_dir + SEP + "refresh_cws_token.sh"),
+			Paths.get(cws_root + SEP + "refresh_cws_token.sh"));
 
 		if (installConsole) {
 			updateCwsUiConfig();
@@ -2012,19 +2012,19 @@ public class CwsInstaller {
 		content = content.replace("__CWS_CONSOLE_SSL_PORT__", cws_console_ssl_port);
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "stop_cws.sh"),
-				Paths.get(cws_root + SEP + "stop_cws.sh"));
+			Paths.get(config_work_dir + SEP + "stop_cws.sh"),
+			Paths.get(cws_root + SEP + "stop_cws.sh"));
 
 		// UPDATE bpm-platform.xml
 		//
 		copy(
-				Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "bpm-platform.xml"),
-				Paths.get(cws_tomcat_root + SEP + "conf" + SEP + "bpm-platform.xml"));
+			Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "bpm-platform.xml"),
+			Paths.get(cws_tomcat_root + SEP + "conf" + SEP + "bpm-platform.xml"));
 
 		// COPY css-jaas.cfg to tomcat/lib
 		copy(
-				Paths.get(config_work_dir + SEP + "tomcat_lib" + SEP + "css-jaas.cfg"),
-				Paths.get(cws_tomcat_root + SEP + "lib" + SEP + "css-jaas.cfg"));
+			Paths.get(config_work_dir + SEP + "tomcat_lib" + SEP + "css-jaas.cfg"),
+			Paths.get(cws_tomcat_root + SEP + "lib" + SEP + "css-jaas.cfg"));
 
 		// UPDATE server.xml
 		print(" Updating server.xml (to point to CWS database)...");
@@ -2042,8 +2042,8 @@ public class CwsInstaller {
 
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "server.xml"),
-				Paths.get(cws_tomcat_root + SEP + "conf"        + SEP + "server.xml"));
+			Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "server.xml"),
+			Paths.get(cws_tomcat_root + SEP + "conf"        + SEP + "server.xml"));
 
 		updateWorkerAppContext();
 		updateWorkerProperties();
@@ -2319,7 +2319,7 @@ public class CwsInstaller {
 		writeToFile(path, content);
 
 		copy(path,
-				Paths.get(cws_tomcat_webapps + SEP + "cws-ui" + SEP + "WEB-INF" + SEP + "applicationContext.xml"));
+			Paths.get(cws_tomcat_webapps + SEP + "cws-ui" + SEP + "WEB-INF" + SEP + "applicationContext.xml"));
 
 
 		// Update clean_es_history.sh file
@@ -2377,9 +2377,9 @@ public class CwsInstaller {
 			Path indexHtml = Paths.get(cws_tomcat_webapps + SEP + cws_project_webapp_root + SEP + "index.html");
 			writeToFile(indexHtml,
 					"<html><head><meta http-equiv=\"refresh\" content=\"10;url=/cws-ui/\" /></head>" +
-							"<body>You have configured CWS to have a project web page.\n" +
-							"Put your custom content here by editing the '" + indexHtml + "' file...<br/><br/><hr/>" +
-							"Automatically redirecting to <a href=\"/cws-ui\">CWS Home</a> in 10 seconds...</body></html>");
+					"<body>You have configured CWS to have a project web page.\n" +
+					"Put your custom content here by editing the '" + indexHtml + "' file...<br/><br/><hr/>" +
+					"Automatically redirecting to <a href=\"/cws-ui\">CWS Home</a> in 10 seconds...</body></html>");
 		}
 	}
 
@@ -2490,8 +2490,8 @@ public class CwsInstaller {
 
 		print(" Put logstash conf file into place.");
 		copy(
-				Paths.get(config_work_dir + SEP + "logging" + SEP + "cws-logstash.conf"),
-				Paths.get(logstash_root   + SEP + "cws-logstash.conf"));
+			Paths.get(config_work_dir + SEP + "logging" + SEP + "cws-logstash.conf"),
+			Paths.get(logstash_root   + SEP + "cws-logstash.conf"));
 	}
 
 	private static void writeOutConfigurationFile() {

--- a/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
+++ b/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
@@ -721,10 +721,10 @@ public class CwsInstaller {
 			} else {
 				if (cws_auth_scheme.equalsIgnoreCase("LDAP")) {
 					cws_user = readLine("Enter name of LDAP user to be used as initial administrator. " +
-							"Default is " + cws_user + ": ", cws_user);
+									"Default is " + cws_user + ": ", cws_user);
 				} else {
 					cws_user = readLine("Enter username to be used as initial administrator. " +
-							"Default is " + cws_user + ": ", cws_user);
+									"Default is " + cws_user + ": ", cws_user);
 				}
 			}
 		} else {
@@ -795,7 +795,7 @@ public class CwsInstaller {
 						"Must specify at least one email address!");
 			} else {
 				cws_notification_emails = readLine("Enter email addresses used to notify of system errors. " +
-						"Default is " + cws_notification_emails + ": ", cws_notification_emails);
+								"Default is " + cws_notification_emails + ": ", cws_notification_emails);
 			}
 		} else {
 			if (cws_notification_emails == null) {
@@ -1868,8 +1868,8 @@ public class CwsInstaller {
 			while ((process = input.readLine()) != null) {
 				//System.out.println(line);
 				if (process.contains("ntpd") ||
-						process.contains("chronyd") ||
-						process.contains("usr/libexec/timed")) {
+					process.contains("chronyd") ||
+					process.contains("usr/libexec/timed")) {
 					print("   [OK]");
 					print("");
 					return 0; // no warnings
@@ -1990,8 +1990,8 @@ public class CwsInstaller {
 		content = content.replace("__CWS_AUTH_SCHEME__",       cws_auth_scheme);
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "refresh_cws_token.sh"),
-				Paths.get(cws_root + SEP + "refresh_cws_token.sh"));
+			Paths.get(config_work_dir + SEP + "refresh_cws_token.sh"),
+			Paths.get(cws_root + SEP + "refresh_cws_token.sh"));
 
 		if (installConsole) {
 			updateCwsUiConfig();
@@ -2006,19 +2006,19 @@ public class CwsInstaller {
 		content = content.replace("__CWS_CONSOLE_SSL_PORT__", cws_console_ssl_port);
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "stop_cws.sh"),
-				Paths.get(cws_root + SEP + "stop_cws.sh"));
+			Paths.get(config_work_dir + SEP + "stop_cws.sh"),
+			Paths.get(cws_root + SEP + "stop_cws.sh"));
 
 		// UPDATE bpm-platform.xml
 		//
 		copy(
-				Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "bpm-platform.xml"),
-				Paths.get(cws_tomcat_root + SEP + "conf" + SEP + "bpm-platform.xml"));
+			Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "bpm-platform.xml"),
+			Paths.get(cws_tomcat_root + SEP + "conf" + SEP + "bpm-platform.xml"));
 
 		// COPY css-jaas.cfg to tomcat/lib
 		copy(
-				Paths.get(config_work_dir + SEP + "tomcat_lib" + SEP + "css-jaas.cfg"),
-				Paths.get(cws_tomcat_root + SEP + "lib" + SEP + "css-jaas.cfg"));
+			Paths.get(config_work_dir + SEP + "tomcat_lib" + SEP + "css-jaas.cfg"),
+			Paths.get(cws_tomcat_root + SEP + "lib" + SEP + "css-jaas.cfg"));
 
 		// UPDATE server.xml
 		print(" Updating server.xml (to point to CWS database)...");
@@ -2036,8 +2036,8 @@ public class CwsInstaller {
 
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "server.xml"),
-				Paths.get(cws_tomcat_root + SEP + "conf"        + SEP + "server.xml"));
+			Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "server.xml"),
+			Paths.get(cws_tomcat_root + SEP + "conf"        + SEP + "server.xml"));
 
 		updateWorkerAppContext();
 		updateWorkerProperties();
@@ -2072,8 +2072,8 @@ public class CwsInstaller {
 		}
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "web.xml"),
-				Paths.get(cws_tomcat_root + SEP + "conf" + SEP + "web.xml"));
+			Paths.get(config_work_dir + SEP + "tomcat_conf" + SEP + "web.xml"),
+			Paths.get(cws_tomcat_root + SEP + "conf" + SEP + "web.xml"));
 
 		// UPDATE camunda/web.xml
 		print(" Updating webapps/camunda/WEB_INF/web.xml..");
@@ -2084,8 +2084,8 @@ public class CwsInstaller {
 
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "camunda_mods" + SEP + "web.xml"),
-				Paths.get(cws_tomcat_webapps + SEP + "camunda" + SEP + "WEB-INF" + SEP + "web.xml"));
+			Paths.get(config_work_dir + SEP + "camunda_mods" + SEP + "web.xml"),
+			Paths.get(cws_tomcat_webapps + SEP + "camunda" + SEP + "WEB-INF" + SEP + "web.xml"));
 
 		// UPDATE engine-rest/web.xml
 		print(" Updating webapps/engine-rest/WEB_INF/web.xml..");
@@ -2095,8 +2095,8 @@ public class CwsInstaller {
 		content = content.replace("__CWS_SECURITY_FILTER_CLASS__", cws_security_filter_class);
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "engine-rest_mods" + SEP + "web.xml"),
-				Paths.get(cws_tomcat_webapps + SEP + "engine-rest" + SEP + "WEB-INF" + SEP + "web.xml"));
+			Paths.get(config_work_dir + SEP + "engine-rest_mods" + SEP + "web.xml"),
+			Paths.get(cws_tomcat_webapps + SEP + "engine-rest" + SEP + "WEB-INF" + SEP + "web.xml"));
 
 		deleteDirectory(new File(cws_tomcat_webapps + SEP + "h2"));
 		deleteDirectory(new File(cws_tomcat_webapps + SEP + "manager"));
@@ -2175,8 +2175,8 @@ public class CwsInstaller {
 		}
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "cws-engine" + SEP + "cws-engine.properties"),
-				Paths.get(cws_tomcat_webapps + SEP + "cws-engine" + SEP + "WEB-INF" + SEP + "classes" + SEP + "cws-engine.properties"));
+			Paths.get(config_work_dir + SEP + "cws-engine" + SEP + "cws-engine.properties"),
+			Paths.get(cws_tomcat_webapps + SEP + "cws-engine" + SEP + "WEB-INF" + SEP + "classes" + SEP + "cws-engine.properties"));
 	}
 
 
@@ -2204,12 +2204,12 @@ public class CwsInstaller {
 		content = content.replace("__CWS_AMQ_HOST__", cws_amq_host);
 		content = content.replace("__CWS_AMQ_PORT__", cws_amq_port);
 
-		content = updateIdentityPluginContent(content);
+	content = updateIdentityPluginContent(content);
 
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "cws-engine" + SEP + "applicationContext.xml"),
-				Paths.get(cws_tomcat_webapps + SEP + "cws-engine" + SEP + "WEB-INF" + SEP + "applicationContext.xml"));
+			Paths.get(config_work_dir + SEP + "cws-engine" + SEP + "applicationContext.xml"),
+			Paths.get(cws_tomcat_webapps + SEP + "cws-engine" + SEP + "WEB-INF" + SEP + "applicationContext.xml"));
 	}
 
 
@@ -2269,8 +2269,8 @@ public class CwsInstaller {
 
 		writeToFile(filePath, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "cws-ui" + SEP + "cws-ui.properties"),
-				Paths.get(cws_tomcat_webapps + SEP + "cws-ui" + SEP + "WEB-INF" + SEP + "classes" + SEP + "cws-ui.properties"));
+			Paths.get(config_work_dir + SEP + "cws-ui" + SEP + "cws-ui.properties"),
+			Paths.get(cws_tomcat_webapps + SEP + "cws-ui" + SEP + "WEB-INF" + SEP + "classes" + SEP + "cws-ui.properties"));
 	}
 
 
@@ -2308,12 +2308,12 @@ public class CwsInstaller {
 		}
 		content = content.replace("__UNIQUE_BROKER_GROUP_NAME__", unique_broker_group_name);
 
-		content = updateIdentityPluginContent(content);
+	content = updateIdentityPluginContent(content);
 
-		writeToFile(path, content);
+	writeToFile(path, content);
 
 		copy(path,
-				Paths.get(cws_tomcat_webapps + SEP + "cws-ui" + SEP + "WEB-INF" + SEP + "applicationContext.xml"));
+			Paths.get(cws_tomcat_webapps + SEP + "cws-ui" + SEP + "WEB-INF" + SEP + "applicationContext.xml"));
 
 
 		// Update clean_es_history.sh file
@@ -2329,8 +2329,8 @@ public class CwsInstaller {
 		content = content.replace("__CWS_HISTORY_DAYS_TO_LIVE__", 	history_days_to_live);
 		writeToFile(path, content);
 		copy(
-				Paths.get(config_work_dir + SEP + "clean_es_history.sh"),
-				Paths.get(cws_root + SEP + "clean_es_history.sh"));
+			Paths.get(config_work_dir + SEP + "clean_es_history.sh"),
+			Paths.get(cws_root + SEP + "clean_es_history.sh"));
 
 
 		// UPDATE cws-ui brand name in FTL files
@@ -2370,10 +2370,10 @@ public class CwsInstaller {
 			mkDir(cws_tomcat_webapps + SEP + cws_project_webapp_root);
 			Path indexHtml = Paths.get(cws_tomcat_webapps + SEP + cws_project_webapp_root + SEP + "index.html");
 			writeToFile(indexHtml,
-					"<html><head><meta http-equiv=\"refresh\" content=\"10;url=/cws-ui/\" /></head>" +
-							"<body>You have configured CWS to have a project web page.\n" +
-							"Put your custom content here by editing the '" + indexHtml + "' file...<br/><br/><hr/>" +
-							"Automatically redirecting to <a href=\"/cws-ui\">CWS Home</a> in 10 seconds...</body></html>");
+				"<html><head><meta http-equiv=\"refresh\" content=\"10;url=/cws-ui/\" /></head>" +
+				"<body>You have configured CWS to have a project web page.\n" +
+				"Put your custom content here by editing the '" + indexHtml + "' file...<br/><br/><hr/>" +
+				"Automatically redirecting to <a href=\"/cws-ui\">CWS Home</a> in 10 seconds...</body></html>");
 		}
 	}
 
@@ -2484,8 +2484,8 @@ public class CwsInstaller {
 
 		print(" Put logstash conf file into place.");
 		copy(
-				Paths.get(config_work_dir + SEP + "logging" + SEP + "cws-logstash.conf"),
-				Paths.get(logstash_root   + SEP + "cws-logstash.conf"));
+			Paths.get(config_work_dir + SEP + "logging" + SEP + "cws-logstash.conf"),
+			Paths.get(logstash_root   + SEP + "cws-logstash.conf"));
 	}
 
 	private static void writeOutConfigurationFile() {

--- a/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
+++ b/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
@@ -1827,11 +1827,6 @@ public class CwsInstaller {
 				cmdArray = new String[] {"curl", "--fail", "-u", elasticsearch_username + ":" + elasticsearch_password, elasticsearch_host + ":" + elasticsearch_port + "/_cluster/health"};
 			}
 
-			if (elasticsearch_use_auth.equalsIgnoreCase("N")) {
-				// Add auth to curl
-				cmdArray = new String[] {"curl", "--fail", elasticsearch_host + ":" + elasticsearch_port + "/_cluster/health"};
-			}
-
 			Process p = Runtime.getRuntime().exec(cmdArray);
 
 			// Wait for the process to complete

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -405,8 +405,6 @@ public class RestService extends MvcCore {
 	 * @return fully constructed elasticsearch URL string
 	 */
 	private String constructElasticsearchUrl(String subPath) {
-		//String urlString = elasticsearchUseUnsecured.equalsIgnoreCase("N")? "https://" : "http://";
-		//urlString += elasticsearchHostname + ":" + elasticsearchPort + subPath;
 		String urlString = elasticsearchHostname + ":" + elasticsearchPort + subPath;
 		return urlString;
 	}

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -112,7 +112,6 @@ public class RestService extends MvcCore {
 	@Value("${cws.elasticsearch.hostname}") private String elasticsearchHostname;
 	@Value("${cws.elasticsearch.port}") private String elasticsearchPort;
 
-	@Value("${cws.elasticsearch.use.unsecured}") private String elasticsearchUseUnsecured;
 	@Value("${cws.elasticsearch.use.auth}") private String elasticsearchUseAuth;
 	@Value("${cws.elasticsearch.username}") private String elasticsearchUsername;
 	@Value("${cws.elasticsearch.password}") private String elasticsearchPassword;
@@ -415,15 +414,6 @@ public class RestService extends MvcCore {
 		System.out.println("**************************************************");
 
 		return urlString;
-	}
-
-
-	/**
-	 *
-	 * @return boolean indicating whether elasticsearch use https or http
-	 */
-	private Boolean elasticsearchUseUnsecured() {
-		return elasticsearchUseUnsecured.equalsIgnoreCase("N");
 	}
 
 

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -408,14 +408,8 @@ public class RestService extends MvcCore {
 		//String urlString = elasticsearchUseUnsecured.equalsIgnoreCase("N")? "https://" : "http://";
 		//urlString += elasticsearchHostname + ":" + elasticsearchPort + subPath;
 		String urlString = elasticsearchHostname + ":" + elasticsearchPort + subPath;
-
-		System.out.println("**************************************************");
-		System.out.println(urlString);
-		System.out.println("**************************************************");
-
 		return urlString;
 	}
-
 
 	/**
 	 *

--- a/dev.sh
+++ b/dev.sh
@@ -71,7 +71,7 @@ BASE_PORT=8000
 tab ${DIST}/console-only/cws "./start_cws.sh -d $BASE_PORT; tail -f $LOG_FILE"
 
 print "Waiting for console startup..."
-sleep 160
+sleep 100
 
 # -----------------
 # CONFIGURE WORKERS
@@ -98,7 +98,7 @@ done
 # START WORKERS
 # -------------
 for ((WORKER_NUM=1; WORKER_NUM <= $NUM_WORKERS; WORKER_NUM++)); do
-	sleep 20
+	sleep 5
 
 	print "Starting worker ${WORKER_NUM}..."
 	WORKER_TAG="worker${WORKER_NUM}"


### PR DESCRIPTION
# Description

CWS elasticsearch connection is set to SSL by default. 

Dev Script config -- ElasticSearch parameters now have 3 ways to set configuration for External ES authentication.

### HTTPS **_with_** Username/Password auth input
- [x] 1. 

* Tested: Deployed `external_pwd` process 
* CWS System Logs works
* System Summary page: Elasticsearch cluster health passed



### HTTPS **_without_** Username/Password auth input
 - [x] 2. 


* Tested: Deployed `external_pwd` process 
* CWS System Logs works
* System Summary page: Elasticsearch cluster health passed





### HTTP no Username/Password auth input
- [x] 3. 

* Tested: Deployed `external_pwd` process 
* CWS System Logs works
* System Summary page: Elasticsearch cluster health passed
