### PR TITLE
Enable compilation up to JDK 17.

### DIFF
--- a/cws-service/pom.xml
+++ b/cws-service/pom.xml
@@ -253,6 +253,15 @@
 					<groupId>org.xmlunit</groupId>
 					<artifactId>xmlunit-core</artifactId>
 				</dependency>
+
+				<!-- Java 11+ no longer has javax.annotation included -->
+				<!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
+				<dependency>
+					<groupId>javax.annotation</groupId>
+					<artifactId>javax.annotation-api</artifactId>
+					<version>1.3.2</version>
+					<scope>provided</scope>
+				</dependency>
 			</dependencies>
 		</profile>
 	</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,8 @@
 		<mariadb-java-client.version>2.7.2</mariadb-java-client.version>
 
 		<maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven-dependency-plugin.version>3.0.1</maven-dependency-plugin.version>
 		<maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
 		<maven-install-plugin.version>2.5.2</maven-install-plugin.version>


### PR DESCRIPTION
Unfortunately, M1 Macs do not have JDK 8 available (either via OpenJDK or Corretto), and compiling JDK 8 from source requires having JDK 7 or JDK 8 already compiled for the platform. Cross compiling the JDK is not easily achieved, either.

However, it turns out the migration past JDK 8 here is fairly straightforward:

* `cws-service` uses `javax.annotation`, which was removed from JDK 11 and moved into a separate package (`javax.annotations-api`). This should not affect earlier JDK builds.
* The default source/target version for `maven-compiler-plugin` 3.6 appears to be JDK 5, which is no longer supported. Upping this to 6 (1.6) resolves the issue. (There are no significant changes to source interpretation between 5 and 6, like there was between 3 and 4.)
