### PR TITLE
fix: Console Worker ID

### DIFF
--- a/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
@@ -148,8 +148,13 @@ public class EngineDbService extends DbService implements InitializingBean {
 	 */
 	public void createOrUpdateWorkerRow(String lockOwner) {
 		if (!workerExists()) {
-
-			if (!cwsInstallType.equals("console_only") && !workerConsoleOnlyTypeExists()) {
+			if ( (cwsInstallType.equals("console_only") && workerConsoleOnlyTypeExists()) ) {
+				//
+				// ROW FOR CONSOLE ONLY WORKER ALREADY EXISTS
+				//
+				log.info("Worker Row with cws_install_type: " + cwsInstallType ", already exists. ");
+			}
+			else {
 				//
 				// ROW FOR WORKER DOES NOT EXIST, SO CREATE ONE
 				//
@@ -166,7 +171,7 @@ public class EngineDbService extends DbService implements InitializingBean {
 					workerName = "worker-" + System.currentTimeMillis();
 					// newly added
 					if (cwsInstallType.equals("console_only")) {
-						workerName = "worker" + "0000";
+						workerName = "worker-" + "0000";
 					}
 
 					try {

--- a/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
@@ -148,11 +148,11 @@ public class EngineDbService extends DbService implements InitializingBean {
 	 */
 	public void createOrUpdateWorkerRow(String lockOwner) {
 		if (!workerExists()) {
-			if ( (cwsInstallType.equals("console_only") && workerConsoleOnlyTypeExists()) ) {
+			if ( cwsInstallType.equals("console_only") && workerConsoleOnlyTypeExists() ) {
 				//
 				// ROW FOR CONSOLE ONLY WORKER ALREADY EXISTS
 				//
-				log.info("Worker Row with cws_install_type: " + cwsInstallType ", already exists. ");
+				log.info("Worker Row with cws_install_type: " + cwsInstallType + ", already exists. ");
 			}
 			else {
 				//

--- a/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
@@ -43,6 +43,10 @@ public class EngineDbService extends DbService implements InitializingBean {
 	public boolean workerExists() {
 		return jdbcTemplate.queryForObject("SELECT count(*) FROM cws_worker WHERE id=?", new Object[]{workerId}, Integer.class) > 0;
 	}
+
+	public boolean workerConsoleOnlyTypeExists() {
+		return jdbcTemplate.queryForObject("SELECT count(*) FROM cws_worker WHERE cws_install_type=?", new Object[]{cwsInstallType}, Integer.class) > 0;
+	}
 	
 	private boolean workerLogExists(String filename) {
 		return jdbcTemplate.queryForObject(
@@ -144,68 +148,71 @@ public class EngineDbService extends DbService implements InitializingBean {
 	 */
 	public void createOrUpdateWorkerRow(String lockOwner) {
 		if (!workerExists()) {
-			//
-			// ROW FOR WORKER DOES NOT EXIST, SO CREATE ONE
-			//
 
-			int numUpdated = 0;
-			int numTries = 0;
-			String workerName = null;
-			while (numTries++ < 10 && numUpdated != 1) {
-				Timestamp tsNow = new Timestamp(DateTime.now().getMillis());
+			if (!cwsInstallType.equals("console_only") && !workerConsoleOnlyTypeExists()) {
+				//
+				// ROW FOR WORKER DOES NOT EXIST, SO CREATE ONE
+				//
 
-				// Determine a worker name, using current system time in milliseconds.
-				// TODO: In the future, we might want to do a more elegant algorithm,
-				//       but this may just be fine for the long-run
-				workerName = "worker-" + System.currentTimeMillis();
-				if (cwsInstallType.equals("console_only")) {
-					workerName = "worker" + "0000";
-				}
-				
-				try {
-					log.info("Inserting row (attempt #" + numTries +", workerName='"+workerName+"') into cws_worker table...");
-					log.info("-- cwsInstallType:" + cwsInstallType + "--");
+				int numUpdated = 0;
+				int numTries = 0;
+				String workerName = null;
+				while (numTries++ < 10 && numUpdated != 1) {
+					Timestamp tsNow = new Timestamp(DateTime.now().getMillis());
 
-					numUpdated = jdbcTemplate.update(
-							"INSERT INTO cws_worker" +
-							"   (id, lock_owner, name, install_directory, cws_install_type, cws_worker_type, " +
-							"    status, job_executor_max_pool_size, created_time, last_heartbeat_time) " +
-							"VALUES (?,?,?,?,?,?,?,?,?,?)",
-							new Object[] {
-									workerId,
-									lockOwner,
-									workerName,
-									"install_directory_TODO",
-									cwsInstallType,
-									cwsWorkerType,
-									null, // status will be changed to null once the worker is fully initialized
-									maxExecutorServicePoolSize, // changeable later via the UI..
-									tsNow, // created_time
-									tsNow  // last_heartbeat_time
-							});
-				}
-				catch (Exception e) {
-					log.error("Problem encountered while inserting row (attempt #" +
-							numTries +", workerName='"+workerName+"') into cws_worker table", e);
+					// Determine a worker name, using current system time in milliseconds.
+					// TODO: In the future, we might want to do a more elegant algorithm,
+					//       but this may just be fine for the long-run
+					workerName = "worker-" + System.currentTimeMillis();
+					// newly added
+					if (cwsInstallType.equals("console_only")) {
+						workerName = "worker" + "0000";
+					}
+
 					try {
-						// Could not update database, wait and retry again
-						Thread.sleep((long)(Math.random() * 500.0));
+						log.info("Inserting row (attempt #" + numTries + ", workerName='" + workerName + "') into cws_worker table...");
+						log.info("cwsInstallType:" + cwsInstallType);
+
+						numUpdated = jdbcTemplate.update(
+							"INSERT INTO cws_worker" +
+								"   (id, lock_owner, name, install_directory, cws_install_type, cws_worker_type, " +
+								"    status, job_executor_max_pool_size, created_time, last_heartbeat_time) " +
+								"VALUES (?,?,?,?,?,?,?,?,?,?)",
+							new Object[]{
+								workerId,
+								lockOwner,
+								workerName,
+								"install_directory_TODO",
+								cwsInstallType,
+								cwsWorkerType,
+								null, // status will be changed to null once the worker is fully initialized
+								maxExecutorServicePoolSize, // changeable later via the UI..
+								tsNow, // created_time
+								tsNow  // last_heartbeat_time
+							});
+					} catch (Exception e) {
+						log.error("Problem encountered while inserting row (attempt #" +
+							numTries + ", workerName='" + workerName + "') into cws_worker table", e);
+						try {
+							// Could not update database, wait and retry again
+							Thread.sleep((long) (Math.random() * 500.0));
+						} catch (InterruptedException ex) {
+							log.warn("Thread interrupt encountered while sleeping for inserting row (attempt #" +
+								numTries + ", workerName='" + workerName + "')");
+						}
 					}
-					catch (InterruptedException ex) {
-						log.warn("Thread interrupt encountered while sleeping for inserting row (attempt #" +
-								numTries +", workerName='"+workerName+"')");
-					}
+				} // end while try to insert
+
+				if (numUpdated != 1) {
+					log.error("Could not create worker row for (workerId='" + workerId + "', workerName='" + workerName + "', " +
+						"numUpdated=" + numUpdated + ") " +
+						" after " + numTries + " attempts!");
+				} else {
+					log.debug("Inserted cws_worker row for (workerId='" + workerId + "', workerName='" + workerName + "')");
 				}
-			} // end while try to insert
-			
-			if (numUpdated != 1) {
-				log.error("Could not create worker row for (workerId='"+workerId+"', workerName='"+workerName+"', " +
-						"numUpdated="+numUpdated+") " +
-						" after "+numTries+" attempts!");
+
 			}
-			else {
-				log.debug("Inserted cws_worker row for (workerId='"+workerId+"', workerName='"+workerName+"')");
-			}
+
 		}
 		else {
 			//

--- a/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
@@ -152,13 +152,12 @@ public class EngineDbService extends DbService implements InitializingBean {
 				//
 				// ROW FOR CONSOLE ONLY WORKER ALREADY EXISTS
 				//
-				log.info("Worker Row with cws_install_type: " + cwsInstallType + ", already exists. ");
+				log.warn("Worker Row with cws_install_type: " + cwsInstallType + ", already exists. ");
 			}
 			else {
 				//
 				// ROW FOR WORKER DOES NOT EXIST, SO CREATE ONE
 				//
-
 				int numUpdated = 0;
 				int numTries = 0;
 				String workerName = null;
@@ -171,7 +170,7 @@ public class EngineDbService extends DbService implements InitializingBean {
 					workerName = "worker-" + System.currentTimeMillis();
 					// newly added
 					if (cwsInstallType.equals("console_only")) {
-						workerName = "worker-" + "0000";
+						workerName = "worker0000";
 					}
 
 					try {

--- a/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
@@ -152,7 +152,7 @@ public class EngineDbService extends DbService implements InitializingBean {
 				//
 				// ROW FOR CONSOLE ONLY WORKER ALREADY EXISTS
 				//
-				log.warn("Worker Row with cws_install_type: " + cwsInstallType + ", already exists. ");
+				log.error("Worker Row with cws_install_type: " + cwsInstallType + ", already exists. ");
 			}
 			else {
 				//

--- a/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/EngineDbService.java
@@ -158,9 +158,13 @@ public class EngineDbService extends DbService implements InitializingBean {
 				// TODO: In the future, we might want to do a more elegant algorithm,
 				//       but this may just be fine for the long-run
 				workerName = "worker-" + System.currentTimeMillis();
+				if (cwsInstallType.equals("console_only")) {
+					workerName = "worker" + "0000";
+				}
 				
 				try {
 					log.info("Inserting row (attempt #" + numTries +", workerName='"+workerName+"') into cws_worker table...");
+					log.info("-- cwsInstallType:" + cwsInstallType + "--");
 
 					numUpdated = jdbcTemplate.update(
 							"INSERT INTO cws_worker" +


### PR DESCRIPTION
## Ticket: https://github.com/NASA-AMMOS/common-workflow-service/issues/54


### Fix:

* `console_only` row set `name`=worker0000
* Only 1 row with cws_install_type `console_only` can be created in DB table _cws_worker_


<img width="565" alt="Screen Shot 2021-12-14 at 12 44 29 PM" src="https://user-images.githubusercontent.com/35245966/146076529-6ed09fc6-4bfd-4826-9ae3-b2380979557a.png">

