### PR TITLE
fixed Elasticsearch http https validation

### DIFF
--- a/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
+++ b/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
@@ -1877,6 +1877,13 @@ public class CwsInstaller {
 				return 1;
 			}
 
+			if (!(elasticsearch_host.startsWith("https://") || elasticsearch_host.startsWith("http://")) ) {
+				print("   [WARNING]");
+				print("       It was determined that the user provided Elasticsearch endpoint '" + elasticsearch_host + "' did not properly set or include protocol 'http://' OR 'https://'");
+				print("");
+				return 1;
+			}
+
 			print("   [OK]");
 			print("");
 			return 0; // no warnings


### PR DESCRIPTION
Validation added to user provided `ES_HOST`. Checks for protocol in ES endpoint.


Incorrect setting: ES_HOST="localhost"

Correct setting: ES_HOST="http://localhost"


```
# ES config
ES_HOST="http://localhost"
ES_PORT=9200
ES_USE_AUTH=n
ES_USERNAME="na"
ES_PASSWORD="na"
```
