### PR TITLE
Bug in Interactive Mode: ES Auth cred setting

### DIFF
--- a/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
+++ b/cws-installer/src/main/java/jpl/cws/task/CwsInstaller.java
@@ -1122,7 +1122,7 @@ public class CwsInstaller {
 								"ERROR: Must specify either 'Y' or 'N'");
 			}
 
-			user_provided_logstash = read_elasticsearch_use_auth.toLowerCase();
+			elasticsearch_use_auth = read_elasticsearch_use_auth.toLowerCase();
 		}
 
 		if (elasticsearch_use_auth.equalsIgnoreCase("Y")) {


### PR DESCRIPTION
### Fix
CWS Install 'Interactive Mode **not** giving prompt for ES username and password for authentication.

<img width="619" alt="Screen Shot 2022-01-27 at 7 38 23 AM" src="https://user-images.githubusercontent.com/35245966/151391719-5fb39d6a-f845-4a78-a7ac-363f7c764b89.png">


**Testing with config.prop has no issue. Only interactive install has bug.
