### PR TITLE
FIX: Add rsync linux package to Dockerfile

### DIFF
--- a/install/docker/cws-image/Dockerfile
+++ b/install/docker/cws-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM oraclelinux:8
 
 RUN yum update -y && \
-    yum install -y mariadb-server java-1.8.0-openjdk java-1.8.0-openjdk-devel rsync && \
+    yum install -y mariadb-server java-1.8.0-openjdk java-1.8.0-openjdk-devel rsync which && \
     yum clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0

--- a/install/docker/cws-image/Dockerfile
+++ b/install/docker/cws-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM oraclelinux:8
 
 RUN yum update -y && \
-    yum install -y mariadb-server java-1.8.0-openjdk java-1.8.0-openjdk-devel && \
+    yum install -y mariadb-server java-1.8.0-openjdk java-1.8.0-openjdk-devel rsync && \
     yum clean all
 
 ENV JAVA_HOME /usr/lib/jvm/java-1.8.0


### PR DESCRIPTION
#### CWS docker image needs 'rsync' package in OracleLinux:8

Rsync is needed to run .configure.sh for reconfiguration and backups

Command: `rsync`
```
[cws_user@cws-console ~]$ rsync --version
rsync  version 3.1.3  protocol version 31
Copyright (C) 1996-2018 by Andrew Tridgell, Wayne Davison, and others.
Web site: http://rsync.samba.org/
Capabilities:
    64-bit files, 64-bit inums, 64-bit timestamps, 64-bit long ints,
    socketpairs, hardlinks, symlinks, IPv6, batchfiles, inplace,
    append, ACLs, xattrs, iconv, symtimes, prealloc

rsync comes with ABSOLUTELY NO WARRANTY.  This is free software, and you
are welcome to redistribute it under certain conditions.  See the GNU
General Public Licence for details.
```

Command: `which java`

```
[cws_user@cws-console ~]$ which java
/usr/bin/java
```

----------

`./configure.sh config.properties Y`


OUTPUT: (.backups/ ; now successfully generated with rsync)
```
[cws_user@cws-console cws]$ ./configure.sh ../config.properties Y
ROOT=/home/cws_user/cws
[configure.sh] Checking Java requirements...
[configure.sh]   JAVA_HOME set  [OK]
[configure.sh]   JAVA_HOME = /usr/lib/jvm/java-1.8.0
[configure.sh]   JAVA_HOME Java version : 1.8.0_322
[configure.sh]   PATH      Java version : 1.8.0_322  /usr/bin/java
[configure.sh]   Java versions match      [OK]
[configure.sh]   Java version == 1.8x     [OK]
[configure.sh]   Java Compiler available  [OK]
[configure.sh] Java requirements met.
[configure.sh] Using installation presets provided from /home/cws_user/config.properties...
Detected re-run of configure.sh, backing up current distribution...
Saving backup of current CWS distribution to /home/cws_user/cws/.backups/backup_20220223_221823...done.
Cleaning out CWS distribution files (this may take a while)...done.
```
