### PR TITLE
Reconfig: preserve user's passed props file when used in `/cws`

### DIFF
--- a/install/configure.sh
+++ b/install/configure.sh
@@ -73,7 +73,7 @@ else
     # Sync CONFIG_FILE used from inside ROOT/
     if [[ ${CONFIG_FILE_BASENAME} != "" && "${CONFIG_FILE_DIR}" == "${ROOT}/${CONFIG_FILE_BASENAME}" ]]; then
         echo "Found config props file in cws root: '${CONFIG_FILE_BASENAME}' "
-        rsync -a "${BACKUP_CURR}/${CONFIG_FILE_BASENAME}" "${ROOT}/"
+        rsync -a --ignore-existing "${BACKUP_CURR}/${CONFIG_FILE_BASENAME}" "${ROOT}/"
     fi
 
     # Sync files back in from clean CWS distribution, but don't overwrite anything we left intentionally

--- a/install/configure.sh
+++ b/install/configure.sh
@@ -8,14 +8,76 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo ROOT=${ROOT}
 
+# ================
+# DECLARE ARGUMENT VARIABLES
+# ================
+CONF_FILE=${1}
+PROMPT_VALUE=${2}
+
+# logic for repeat configure runs
+
+# if this is the very first time configure has been run:
+#  - save the clean CWS distribution code to .backups/clean
+# if this is a repeat run (check if .backups/clean exists)
+#  - create a timestamp-named backup of the current CWS distribution code under ./backups/backup_YYYYMMDD_hhmmss
+#  - remove everything in the current distribution except for user-configured items:
+#    * BPMN models (saved in /path/to/bpmn)
+#    * Code Snippets (saved in the database)
+#    * Initiators (saved in /path/to/cws-process-initiators.xml)
+#  - rsync the ./backups/clean dir back into the current distribution, EXCLUDING the above items
+
+BACKUP_DIR=${ROOT}/.backups
+BACKUP_CLEAN=${BACKUP_DIR}/clean
+
+if [ ! -d "${BACKUP_CLEAN}" ]; then
+    echo "Initializing CWS backup directory... "
+    mkdir -p "${BACKUP_CLEAN}"
+
+    # Save clean CWS before configure.sh is run and directory is modified
+    rsync -a --exclude='.backups' "${ROOT}/" "${BACKUP_CLEAN}/"
+else
+    echo "Detected re-run of configure.sh, backing up current distribution..."
+
+    # Make .backups folder for current CWS property version
+    BACKUP_CURR=${BACKUP_DIR}/backup_$(date '+%Y%m%d_%H%M%S') # .backups/backup_YYYYMMDD_hhmmss format
+
+    # Copy a backup, (excluding the backups dir, we don't want recursive backups)
+    echo -n "Saving backup of current CWS distribution to ${BACKUP_CURR}..."
+    mkdir -p "${BACKUP_CURR}"
+    rsync -a --exclude=".backups" "${ROOT}/" "${BACKUP_CURR}/"
+    echo "done."
+
+    if [[ "${CONF_FILE}" == "" ]]; then
+        CONFIG_FILE_BASENAME=""
+    else
+        CONFIG_FILE_BASENAME=$(basename ${CONF_FILE})
+    fi
+
+    # Due to quirks in MacOS file deletion, this is actually the safest way to delete everything
+    echo -n "Cleaning out CWS distribution files (this may take a while)..."
+    find "${ROOT}/" -mindepth 1 \
+      -not -name "configure.sh" \
+      -not -name "configuration.properties" \
+      -not -name "${CONFIG_FILE_BASENAME}" \
+      -not -name "*cws-process-initiators*" \
+      -not -path "*.backups" \
+      -not -path "*.backups/*" \
+      -not -path "*bpmn/*" \
+      -not -path "*bpmn" \
+      -type f \
+      -exec rm -r {} \; &> /dev/null
+    echo "done."
+
+    # Sync files back in from clean CWS distribution, but don't overwrite anything we left intentionally
+    rsync -a --ignore-existing "${BACKUP_CLEAN}/" "${ROOT}/"
+fi
+
+
 source ${ROOT}/utils.sh
 
 # ================
 # SETUP VARIABLES
 # ================
-CONF_FILE=${1}
-PROMPT_VALUE=${2}
-
 export CWS_HOME=${ROOT}
 export CWS_TOMCAT_HOME=${ROOT}/server/apache-tomcat-${TOMCAT_VER}
 export CWS_INSTALLER_PRESET_FILE=${ROOT}/configuration.properties
@@ -77,64 +139,6 @@ else
 	    # Merge provided configuration with installer presets (defaults)
 	    cat ${CONF_FILE} ${ROOT}/config/installerPresets.properties | awk -F= '!a[$1]++' > ${CWS_INSTALLER_PRESET_FILE}
 	fi
-fi
-
-# logic for repeat configure runs
-
-# if this is the very first time configure has been run:
-#  - save the clean CWS distribution code to .backups/clean
-# if this is a repeat run (check if .backups/clean exists)
-#  - create a timestamp-named backup of the current CWS distribution code under ./backups/backup_YYYYMMDD_hhmmss
-#  - remove everything in the current distribution except for user-configured items:
-#    * BPMN models (saved in /path/to/bpmn)
-#    * Code Snippets (saved in the database)
-#    * Initiators (saved in /path/to/cws-process-initiators.xml)
-#  - rsync the ./backups/clean dir back into the current distribution, EXCLUDING the above items
-
-BACKUP_DIR=${ROOT}/.backups
-BACKUP_CLEAN=${BACKUP_DIR}/clean
-
-if [ ! -d "${BACKUP_CLEAN}" ]; then
-    echo "Initializing CWS backup directory... "
-    mkdir -p "${BACKUP_CLEAN}"
-
-    # Save clean CWS before configure.sh is run and directory is modified
-    rsync -a --exclude='.backups' "${ROOT}/" "${BACKUP_CLEAN}/"
-else
-    echo "Detected re-run of configure.sh, backing up current distribution..."
-
-    # Make .backups folder for current CWS property version
-    BACKUP_CURR=${BACKUP_DIR}/backup_$(date '+%Y%m%d_%H%M%S') # .backups/backup_YYYYMMDD_hhmmss format
-
-    # Copy a backup, (excluding the backups dir, we don't want recursive backups)
-    echo -n "Saving backup of current CWS distribution to ${BACKUP_CURR}..."
-    mkdir -p "${BACKUP_CURR}"
-    rsync -a --exclude=".backups" "${ROOT}/" "${BACKUP_CURR}/"
-    echo "done."
-
-    if [[ "${CONF_FILE}" == "" ]]; then
-        CONFIG_FILE_BASENAME=""
-    else
-    	  CONFIG_FILE_BASENAME=$(basename ${CONF_FILE})
-    fi
-
-    # Due to quirks in MacOS file deletion, this is actually the safest way to delete everything
-    echo -n "Cleaning out CWS distribution files (this may take a while)..."
-    find "${ROOT}/" -mindepth 1 \
-      -not -name "configure.sh" \
-      -not -name "configuration.properties" \
-      -not -name "${CONFIG_FILE_BASENAME}" \
-      -not -name "*cws-process-initiators*" \
-      -not -path "*.backups" \
-      -not -path "*.backups/*" \
-      -not -path "*bpmn/*" \
-      -not -path "*bpmn" \
-      -type f \
-      -exec rm -r {} \; &> /dev/null
-    echo "done."
-
-    # Sync files back in from clean CWS distribution, but don't overwrite anything we left intentionally
-    rsync -a --ignore-existing "${BACKUP_CLEAN}/" "${ROOT}/"
 fi
 
 # --------------------------------------------
@@ -212,7 +216,7 @@ if [[ "${CWS_INSTALL_TYPE}" = "1" ]] || [[ "${CWS_INSTALL_TYPE}" = "2" ]]; then
 	print "  DB NAME:   ${DB_NAME}"
 	print "  DB USER:   ${DB_USER}"
 	print "This script will now create the database necessary for CWS to function."
-	
+
 	while [[ ! ${REPLY} =~ $(echo "^(y|Y|n|N)$") ]]; do
 		if [[ "${PROMPT_VALUE}" == "" ]]; then
 			read -p "Continue? (Y/N): " REPLY

--- a/install/configure.sh
+++ b/install/configure.sh
@@ -8,58 +8,6 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 echo ROOT=${ROOT}
 
-# logic for repeat configure runs
-
-# if this is the very first time configure has been run:
-#  - save the clean CWS distribution code to .backups/clean
-# if this is a repeat run (check if .backups/clean exists)
-#  - create a timestamp-named backup of the current CWS distribution code under ./backups/backup_YYYYMMDD_hhmmss
-#  - remove everything in the current distribution except for user-configured items:
-#    * BPMN models (saved in /path/to/bpmn)
-#    * Code Snippets (saved in the database)
-#    * Initiators (saved in /path/to/cws-process-initiators.xml)
-#  - rsync the ./backups/clean dir back into the current distribution, EXCLUDING the above items
-
-BACKUP_DIR=${ROOT}/.backups
-BACKUP_CLEAN=${BACKUP_DIR}/clean
-
-if [ ! -d "${BACKUP_CLEAN}" ]; then
-    echo "Initializing CWS backup directory... "
-    mkdir -p "${BACKUP_CLEAN}"
-
-    # Save clean CWS before configure.sh is run and directory is modified
-    rsync -a --exclude='.backups' "${ROOT}/" "${BACKUP_CLEAN}/"
-else
-    echo "Detected re-run of configure.sh, backing up current distribution..."
-
-    # Make .backups folder for current CWS property version
-    BACKUP_CURR=${BACKUP_DIR}/backup_$(date '+%Y%m%d_%H%M%S') # .backups/backup_YYYYMMDD_hhmmss format
-
-    # Copy a backup, (excluding the backups dir, we don't want recursive backups)
-    echo -n "Saving backup of current CWS distribution to ${BACKUP_CURR}..."
-    mkdir -p "${BACKUP_CURR}"
-    rsync -a --exclude=".backups" "${ROOT}/" "${BACKUP_CURR}/"
-    echo "done."
-
-    # Due to quirks in MacOS file deletion, this is actually the safest way to delete everything
-    echo -n "Cleaning out CWS distribution files (this may take a while)..."
-    find "${ROOT}/" -mindepth 1 \
-      -not -name "configure.sh" \
-      -not -name "configuration.properties" \
-      -not -name "*cws-process-initiators*" \
-      -not -path "*.backups" \
-      -not -path "*.backups/*" \
-      -not -path "*bpmn/*" \
-      -not -path "*bpmn" \
-      -type f \
-      -exec rm -r {} \; &> /dev/null
-    echo "done."
-
-    # Sync files back in from clean CWS distribution, but don't overwrite anything we left intentionally
-    rsync -a --ignore-existing "${BACKUP_CLEAN}/" "${ROOT}/"
-fi
-
-
 source ${ROOT}/utils.sh
 
 # ================
@@ -129,6 +77,64 @@ else
 	    # Merge provided configuration with installer presets (defaults)
 	    cat ${CONF_FILE} ${ROOT}/config/installerPresets.properties | awk -F= '!a[$1]++' > ${CWS_INSTALLER_PRESET_FILE}
 	fi
+fi
+
+# logic for repeat configure runs
+
+# if this is the very first time configure has been run:
+#  - save the clean CWS distribution code to .backups/clean
+# if this is a repeat run (check if .backups/clean exists)
+#  - create a timestamp-named backup of the current CWS distribution code under ./backups/backup_YYYYMMDD_hhmmss
+#  - remove everything in the current distribution except for user-configured items:
+#    * BPMN models (saved in /path/to/bpmn)
+#    * Code Snippets (saved in the database)
+#    * Initiators (saved in /path/to/cws-process-initiators.xml)
+#  - rsync the ./backups/clean dir back into the current distribution, EXCLUDING the above items
+
+BACKUP_DIR=${ROOT}/.backups
+BACKUP_CLEAN=${BACKUP_DIR}/clean
+
+if [ ! -d "${BACKUP_CLEAN}" ]; then
+    echo "Initializing CWS backup directory... "
+    mkdir -p "${BACKUP_CLEAN}"
+
+    # Save clean CWS before configure.sh is run and directory is modified
+    rsync -a --exclude='.backups' "${ROOT}/" "${BACKUP_CLEAN}/"
+else
+    echo "Detected re-run of configure.sh, backing up current distribution..."
+
+    # Make .backups folder for current CWS property version
+    BACKUP_CURR=${BACKUP_DIR}/backup_$(date '+%Y%m%d_%H%M%S') # .backups/backup_YYYYMMDD_hhmmss format
+
+    # Copy a backup, (excluding the backups dir, we don't want recursive backups)
+    echo -n "Saving backup of current CWS distribution to ${BACKUP_CURR}..."
+    mkdir -p "${BACKUP_CURR}"
+    rsync -a --exclude=".backups" "${ROOT}/" "${BACKUP_CURR}/"
+    echo "done."
+
+    if [[ "${CONF_FILE}" == "" ]]; then
+        CONFIG_FILE_BASENAME=""
+    else
+    	  CONFIG_FILE_BASENAME=$(basename ${CONF_FILE})
+    fi
+
+    # Due to quirks in MacOS file deletion, this is actually the safest way to delete everything
+    echo -n "Cleaning out CWS distribution files (this may take a while)..."
+    find "${ROOT}/" -mindepth 1 \
+      -not -name "configure.sh" \
+      -not -name "configuration.properties" \
+      -not -name "${CONFIG_FILE_BASENAME}" \
+      -not -name "*cws-process-initiators*" \
+      -not -path "*.backups" \
+      -not -path "*.backups/*" \
+      -not -path "*bpmn/*" \
+      -not -path "*bpmn" \
+      -type f \
+      -exec rm -r {} \; &> /dev/null
+    echo "done."
+
+    # Sync files back in from clean CWS distribution, but don't overwrite anything we left intentionally
+    rsync -a --ignore-existing "${BACKUP_CLEAN}/" "${ROOT}/"
 fi
 
 # --------------------------------------------

--- a/install/configure.sh
+++ b/install/configure.sh
@@ -58,7 +58,6 @@ else
     find "${ROOT}/" -mindepth 1 \
       -not -name "configure.sh" \
       -not -name "configuration.properties" \
-      -not -name "${CONFIG_FILE_BASENAME}" \
       -not -name "*cws-process-initiators*" \
       -not -path "*.backups" \
       -not -path "*.backups/*" \
@@ -67,6 +66,14 @@ else
       -type f \
       -exec rm -r {} \; &> /dev/null
     echo "done."
+
+    # Sync CONFIG_FILE used from inside ROOT/
+    CONFIG_FILE_DIR="$(cd "$(dirname "${CONF_FILE}")"; pwd)/$(basename "${CONF_FILE}")"
+
+    if [[ "${CONFIG_FILE_DIR}" == "${ROOT}/${CONFIG_FILE_BASENAME}" ]]; then
+        echo "Found config file in cws root."
+        rsync -a "${BACKUP_CURR}/${CONFIG_FILE_BASENAME}" "${ROOT}/"
+    fi
 
     # Sync files back in from clean CWS distribution, but don't overwrite anything we left intentionally
     rsync -a --ignore-existing "${BACKUP_CLEAN}/" "${ROOT}/"

--- a/install/configure.sh
+++ b/install/configure.sh
@@ -53,6 +53,9 @@ else
         CONFIG_FILE_BASENAME=$(basename ${CONF_FILE})
     fi
 
+    CONFIG_FILE_DIR="$(cd "$(dirname "${CONF_FILE}")"; pwd)/$(basename "${CONF_FILE}")"
+    echo "${CONFIG_FILE_DIR}"
+
     # Due to quirks in MacOS file deletion, this is actually the safest way to delete everything
     echo -n "Cleaning out CWS distribution files (this may take a while)..."
     find "${ROOT}/" -mindepth 1 \
@@ -68,10 +71,8 @@ else
     echo "done."
 
     # Sync CONFIG_FILE used from inside ROOT/
-    CONFIG_FILE_DIR="$(cd "$(dirname "${CONF_FILE}")"; pwd)/$(basename "${CONF_FILE}")"
-
-    if [[ "${CONFIG_FILE_DIR}" == "${ROOT}/${CONFIG_FILE_BASENAME}" ]]; then
-        echo "Found config file in cws root."
+    if [[ ${CONFIG_FILE_BASENAME} != "" && "${CONFIG_FILE_DIR}" == "${ROOT}/${CONFIG_FILE_BASENAME}" ]]; then
+        echo "Found config props file in cws root: '${CONFIG_FILE_BASENAME}' "
         rsync -a "${BACKUP_CURR}/${CONFIG_FILE_BASENAME}" "${ROOT}/"
     fi
 
@@ -140,12 +141,12 @@ else
         exit 1
     fi
 
-	print "Using installation presets provided from ${CONF_FILE}..."
+	  print "Using installation presets provided from ${CONF_FILE}..."
 
     if [[ ! "${CONF_FILE}" -ef "${CWS_INSTALLER_PRESET_FILE}" ]]; then
 	    # Merge provided configuration with installer presets (defaults)
 	    cat ${CONF_FILE} ${ROOT}/config/installerPresets.properties | awk -F= '!a[$1]++' > ${CWS_INSTALLER_PRESET_FILE}
-	fi
+	  fi
 fi
 
 # --------------------------------------------


### PR DESCRIPTION
The `CONF_FILE` value is passed as arg {1}. The file passed to configure.sh is now copied to /backups and preserved in root directory of cws after configure.sh is run.


```
# ================
# DECLARE ARGUMENT VARIABLES
# ================
CONF_FILE=${1}     # ex: cws-config.props
PROMPT_VALUE=${2}  # ex: Y or N

# Example: ./configure.sh CONF_FILE PROMPT_VALUE
```

Run `configure.sh` in 2 ways:
1. From inside `/cws` root: `./configure.sh cws-internal-config.props Y`
2. From outside `/cws` root: `./configure.sh ../../cws-external-config.props Y`
        (this method does not backup the props file to dir `.backups/`)
