### PR TITLE
Fix: Double Log Output

### DIFF
--- a/cws-installer/src/main/resources/log4j2.properties
+++ b/cws-installer/src/main/resources/log4j2.properties
@@ -25,21 +25,25 @@ appender.console.layout.pattern = INSTALLER: %d{ISO8601}{UTC} %-5p [%20.20t] %30
 # Spring Framework
 logger.springframework.name = org.springframework
 logger.springframework.level = info
+logger.springframework.additivity = false
 logger.springframework.appenderRef.stdout.ref = STDOUT
 
 # CWS
 logger.cws.name = jpl.cws
 logger.cws.level = info
+logger.cws.additivity = false
 logger.cws.appenderRef.stdout.ref = STDOUT
 
 # Javax
 logger.javax.name = javax.activation.level
 logger.javax.level = info
+logger.javax.additivity = false
 logger.javax.appenderRef.stdout.ref = STDOUT
 
 # ActiveMQ
 logger.activemq.name = org.apache.activemq.transport
 logger.activemq.level = info
+logger.activemq.additivity = false
 logger.activemq.appenderRef.stdout.ref = STDOUT
 
 # ROOT

--- a/cws-installer/src/main/resources/log4j2.properties
+++ b/cws-installer/src/main/resources/log4j2.properties
@@ -14,6 +14,7 @@
 # 'status' refers to log messages from Log4j2 itself
 status = warn
 
+
 # console appender
 appender.console.type = Console
 appender.console.name = STDOUT

--- a/install/tomcat_lib/log4j2-tomcat.properties
+++ b/install/tomcat_lib/log4j2-tomcat.properties
@@ -43,31 +43,37 @@ appender.rolling.strategy.fileIndex = nomax
 # Camunda
 logger.camunda.name = org.camunda
 logger.camunda.level = info
+logger.camunda.additivity = false
 logger.camunda.appenderRef.stdout.ref = RollingFile
 
 # Camunda Engine
 logger.camundaEngine.name = org.camunda.bpmn.engine
 logger.camundaEngine.level = warn
+logger.camundaEngine.additivity = false
 logger.camundaEngine.appenderRef.stdout.ref = RollingFile
 
 # Spring Framework
 logger.springframework.name = org.springframework
 logger.springframework.level = info
+logger.springframework.additivity = false
 logger.springframework.appenderRef.stdout.ref = RollingFile
 
 # CWS
 logger.cws.name = jpl.cws
 logger.cws.level = debug
+logger.cws.additivity = false
 logger.cws.appenderRef.stdout.ref = RollingFile
 
 # Javax
 logger.javax.name = javax.activation.level
 logger.javax.level = info
+logger.javax.additivity = false
 logger.javax.appenderRef.stdout.ref = RollingFile
 
 # ActiveMQ
 logger.activemq.name = org.apache.activemq.transport
 logger.activemq.level = info
+logger.activemq.additivity = false
 logger.activemq.appenderRef.stdout.ref = RollingFile
 
 # ROOT


### PR DESCRIPTION


#### Issue:
 Respective primary loggers and the root logger are sending the same event to the Appender which then writes it twice to the Console.

#### Solution: 
add additivity `additivity=false` so all loggers will pass events to the Console but not to the Root Logger.

----------
Double Log BUG:

```
2022-05-23T19:32:43,881 DEBUG [                main] rvice.SpringApplicationContext(  35) - SpringApplicationContext xtor
2022-05-23T19:32:43,881 DEBUG [                main] rvice.SpringApplicationContext(  35) - SpringApplicationContext xtor
2022-05-23T19:32:45,172 INFO  [                main]     org.camunda.bpm.engine.cfg( 132) - ENGINE-12003 Plugin 'ProcessApplicationEventListenerPlugin' activated on process engine 'default2'
2022-05-23T19:32:45,172 INFO  [                main]     org.camunda.bpm.engine.cfg( 132) - ENGINE-12003 Plugin 'ProcessApplicationEventListenerPlugin' activated on process engine 'default2'
2022-05-23T19:32:45,199 INFO  [                main]     org.camunda.bpm.engine.cfg( 132) - ENGINE-12003 Plugin 'SpinProcessEnginePlugin' activated on process engine 'default2'
2022-05-23T19:32:45,199 INFO  [                main]     org.camunda.bpm.engine.cfg( 132) - ENGINE-12003 Plugin 'SpinProcessEnginePlugin' activated on process engine 'default2'
2022-05-23T19:32:45,245 INFO  [                main]               org.camunda.spin( 132) - SPIN-01010 Discovered Spin data format provider: org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormatProvider[name = application/json]
2022-05-23T19:32:45,245 INFO  [                main]               org.camunda.spin( 132) - SPIN-01010 Discovered Spin data format provider: org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormatProvider[name = application/json]
2022-05-23T19:32:46,356 INFO  [                main]               org.camunda.spin( 132) - SPIN-01010 Discovered Spin data format provider: org.camunda.spin.impl.xml.dom.format.DomXmlDataFormatProvider[name = application/xml]
2022-05-23T19:32:46,356 INFO  [                main]               org.camunda.spin( 132) - SPIN-01010 Discovered Spin data format provider: org.camunda.spin.impl.xml.dom.format.DomXmlDataFormatProvider[name = application/xml]
2022-05-23T19:32:46,398 INFO  [                main]               org.camunda.spin( 132) - SPIN-01009 Discovered Spin data format: org.camunda.spin.impl.xml.dom.format.DomXmlDataFormat[name = application/xml]
2022-05-23T19:32:46,398 INFO  [                main]               org.camunda.spin( 132) - SPIN-01009 Discovered Spin data format: org.camunda.spin.impl.xml.dom.format.DomXmlDataFormat[name = application/xml]
2022-05-23T19:32:46,398 INFO  [                main]               org.camunda.spin( 132) - SPIN-01009 Discovered Spin data format: org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat[name = application/json]
2022-05-23T19:32:46,398 INFO  [                main]               org.camunda.spin( 132) - SPIN-01009 Discovered Spin data format: org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat[name = application/json]
2022-05-23T19:32:46,590 INFO  [                main] org.camunda.bpm.dmn.feel.scala( 132) - FEEL/SCALA-01001 Spin value mapper detected
2022-05-23T19:32:46,590 INFO  [                main] org.camunda.bpm.dmn.feel.scala( 132) - FEEL/SCALA-01001 Spin value mapper detected
2022-05-23T19:32:46,989 INFO  [                main]    org.camunda.feel.FeelEngine( 109) - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.feel.impl.JavaValueMapper@1e4333fc, org.camunda.spin.plugin.impl.feel.integration.SpinValueMapper@74589d81)), function-provider: org.camunda.bpm.dmn.feel.impl.scala.function.CustomFunctionTransformer@3a326881, configuration: Configuration(false)]
2022-05-23T19:32:46,989 INFO  [                main]    org.camunda.feel.FeelEngine( 109) - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.feel.impl.JavaValueMapper@1e4333fc, org.camunda.spin.plugin.impl.feel.integration.SpinValueMapper@74589d81)), function-provider: org.camunda.bpm.dmn.feel.impl.scala.function.CustomFunctionTransformer@3a326881, configuration: Configuration(false)]
2022-05-23T19:32:55,897 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.engine.sql'
2022-05-23T19:32:55,897 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.engine.sql'
2022-05-23T19:32:57,277 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.history.sql'
2022-05-23T19:32:57,277 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.history.sql'
2022-05-23T19:32:57,548 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'identity' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.identity.sql'
2022-05-23T19:32:57,548 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'identity' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.identity.sql'
2022-05-23T19:32:58,023 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'case.engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.case.engine.sql'
2022-05-23T19:32:58,023 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'case.engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.case.engine.sql'
2022-05-23T19:32:58,119 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'case.history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.case.history.sql'
2022-05-23T19:32:58,119 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'case.history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.case.history.sql'
2022-05-23T19:32:58,203 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'decision.engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.decision.engine.sql'
2022-05-23T19:32:58,203 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'decision.engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.decision.engine.sql'
2022-05-23T19:32:58,439 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'decision.history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.decision.history.sql'
2022-05-23T19:32:58,439 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'decision.history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.decision.history.sql'
2022-05-23T19:32:58,496 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03067 No history level property found in database
2022-05-23T19:32:58,496 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03067 No history level property found in database

```



With fix (additivity=false):

```
2022-05-25T09:26:51,041 INFO  [                main] ina].[localhost].[/cws-engine]( 643) - Initializing Spring root WebApplicationContext
2022-05-25T09:26:51,854 DEBUG [                main] rvice.SpringApplicationContext(  35) - SpringApplicationContext xtor
2022-05-25T09:26:52,455 INFO  [                main]     org.camunda.bpm.engine.cfg( 132) - ENGINE-12003 Plugin 'ProcessApplicationEventListenerPlugin' activated on process engine 'default2'
2022-05-25T09:26:52,465 INFO  [                main]     org.camunda.bpm.engine.cfg( 132) - ENGINE-12003 Plugin 'SpinProcessEnginePlugin' activated on process engine 'default2'
2022-05-25T09:26:52,481 INFO  [                main]               org.camunda.spin( 132) - SPIN-01010 Discovered Spin data format provider: org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormatProvider[name = application/json]
2022-05-25T09:26:53,076 INFO  [                main]               org.camunda.spin( 132) - SPIN-01010 Discovered Spin data format provider: org.camunda.spin.impl.xml.dom.format.DomXmlDataFormatProvider[name = application/xml]
2022-05-25T09:26:53,099 INFO  [                main]               org.camunda.spin( 132) - SPIN-01009 Discovered Spin data format: org.camunda.spin.impl.xml.dom.format.DomXmlDataFormat[name = application/xml]
2022-05-25T09:26:53,100 INFO  [                main]               org.camunda.spin( 132) - SPIN-01009 Discovered Spin data format: org.camunda.spin.impl.json.jackson.format.JacksonJsonDataFormat[name = application/json]
2022-05-25T09:26:53,231 INFO  [                main] org.camunda.bpm.dmn.feel.scala( 132) - FEEL/SCALA-01001 Spin value mapper detected
2022-05-25T09:26:53,425 INFO  [                main]    org.camunda.feel.FeelEngine( 109) - Engine created. [value-mapper: CompositeValueMapper(List(org.camunda.feel.impl.JavaValueMapper@1f8821a8, org.camunda.spin.plugin.impl.feel.integration.SpinValueMapper@193c221a)), function-provider: org.camunda.bpm.dmn.feel.impl.scala.function.CustomFunctionTransformer@6b8224bc, configuration: Configuration(false)]
2022-05-25T09:26:57,448 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.engine.sql'
2022-05-25T09:26:57,998 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.history.sql'
2022-05-25T09:26:58,135 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'identity' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.identity.sql'
2022-05-25T09:26:58,373 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'case.engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.case.engine.sql'
2022-05-25T09:26:58,430 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'case.history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.case.history.sql'
2022-05-25T09:26:58,480 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'decision.engine' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.decision.engine.sql'
2022-05-25T09:26:58,610 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03016 Performing database operation 'create' on component 'decision.history' with resource 'org/camunda/bpm/engine/db/create/activiti.mariadb.create.decision.history.sql'
2022-05-25T09:26:58,644 INFO  [                main] camunda.bpm.engine.persistence( 132) - ENGINE-03067 No history level property found in database
``` 


