### PR TITLE
IDS-9779: Fix modeler elements error

### DIFF
--- a/install/modeler/install_linux_modeler.sh
+++ b/install/modeler/install_linux_modeler.sh
@@ -17,8 +17,9 @@ if [ ! -f "elements.json" ]; then
     echo "File 'elements.json' does not exists in ${ROOT} directory   "
     echo "+--------------------------------------+"
     echo
-    echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to ${ROOT} before continuing "
-    echo
+    echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to '${ROOT}' before running modeler script "
+    echo Aborting...
+    exit 1
 fi
 
 # Confirm Install

--- a/install/modeler/install_linux_modeler.sh
+++ b/install/modeler/install_linux_modeler.sh
@@ -18,7 +18,7 @@ if [ ! -f "elements.json" ]; then
     echo "+--------------------------------------+"
     echo
     echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to '${ROOT}' before running modeler script "
-    echo Aborting...
+    echo "Exiting..."
     exit 1
 fi
 

--- a/install/modeler/install_linux_modeler.sh
+++ b/install/modeler/install_linux_modeler.sh
@@ -1,11 +1,25 @@
 #!/bin/bash
 
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 echo
 echo "Camunda Modeler Installer for Linux"
 echo
 echo "This will install the Camunda Modeler in this directory:"
 pwd
 echo
+
+if [ ! -f "elements.json" ]; then
+    echo "****************************************"
+    echo "*************** WARNING ! **************"
+    echo "****************************************"
+    echo "+--------------------------------------+"
+    echo "File 'elements.json' does not exists in ${ROOT} directory   "
+    echo "+--------------------------------------+"
+    echo
+    echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to ${ROOT} before continuing "
+    echo
+fi
 
 # Confirm Install
 while [[ ! $REPLY =~ ^(y|Y|n|N)$ ]]; do

--- a/install/modeler/install_mac_modeler.sh
+++ b/install/modeler/install_mac_modeler.sh
@@ -15,7 +15,7 @@ if [ ! -f "elements.json" ]; then
     echo "+--------------------------------------+"
     echo
     echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to '${ROOT}' before running modeler script "
-    echo Aborting...
+    echo "Exiting..."
     exit 1
 fi
 

--- a/install/modeler/install_mac_modeler.sh
+++ b/install/modeler/install_mac_modeler.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
 echo
 echo "Camunda Modeler Installer for Mac OS"
 echo
+
+if [ ! -f "elements.json" ]; then
+    echo "*** WARNING *** : File 'elements.json' does not exists in ${ROOT} directory"
+    echo
+    echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to ${ROOT}"
+    echo
+fi
 
 if [ ! -d "/Applications" ]; then
   echo "Error: Cannot find '/Applications' directory.  Is this a Mac OS machine?"

--- a/install/modeler/install_mac_modeler.sh
+++ b/install/modeler/install_mac_modeler.sh
@@ -7,9 +7,14 @@ echo "Camunda Modeler Installer for Mac OS"
 echo
 
 if [ ! -f "elements.json" ]; then
-    echo "*** WARNING *** : File 'elements.json' does not exists in ${ROOT} directory"
+    echo "****************************************"
+    echo "*************** WARNING ! **************"
+    echo "****************************************"
+    echo "+--------------------------------------+"
+    echo "File 'elements.json' does not exists in ${ROOT} directory   "
+    echo "+--------------------------------------+"
     echo
-    echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to ${ROOT}"
+    echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to ${ROOT} before continuing "
     echo
 fi
 

--- a/install/modeler/install_mac_modeler.sh
+++ b/install/modeler/install_mac_modeler.sh
@@ -14,8 +14,9 @@ if [ ! -f "elements.json" ]; then
     echo "File 'elements.json' does not exists in ${ROOT} directory   "
     echo "+--------------------------------------+"
     echo
-    echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to ${ROOT} before continuing "
-    echo
+    echo "Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to '${ROOT}' before running modeler script "
+    echo Aborting...
+    exit 1
 fi
 
 if [ ! -d "/Applications" ]; then


### PR DESCRIPTION
* This error is encountered when running the install modeler script outside of `/modeler` without elements.json


```
cp: ../elements.json: No such file or directory
```


* This commit adds a warning to the user to run the script from inside `/modeler` OR have elements.json in the same directory as the modeler script.


**If _elements.json_ file is not in the same directory as install_mac_modeler.sh script, it gives a warning.**

```
(base) MT-304569:modeler haile$ ./install_mac_modeler.sh 

Camunda Modeler Installer for Mac OS

****************************************
*************** WARNING ! **************
****************************************
+--------------------------------------+
File 'elements.json' does not exists in /Users/haile/dev_cws/common-workflow-service/install/modeler directory   
+--------------------------------------+

Run the Camunda Modeler Installer from 'modeler/' folder or copy elements.json to /Users/haile/dev_cws/common-workflow-service/install/modeler before continuing 

Installing in '/Applications' directory

*** Warning! ***  This will remove your old Camunda Modeler (if exists) and install the latest version...

Press Y to continue or N to abort. (Y/N): 

```