### PR TITLE
UI - Allow appropriate buttons to open in a new tab

### DIFF
--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/HistoryTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/HistoryTestIT.java
@@ -76,7 +76,7 @@ public class HistoryTestIT extends WebTestUtil {
 			waitForElementID("processes-table");
 
 			log.info("Verifying the header and output from the model.");
-			WebElement historyButton = findElByXPath("//button[contains(text(),'History')]");
+			WebElement historyButton = findElByXPath("//a[contains(text(),'History')]");
 			waitForElement(historyButton);
 			scrollTo(historyButton);
 			historyButton.click();

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/HistoryTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/HistoryTestIT.java
@@ -76,7 +76,7 @@ public class HistoryTestIT extends WebTestUtil {
 			waitForElementID("processes-table");
 
 			log.info("Verifying the header and output from the model.");
-			WebElement historyButton = findElByXPath("//a[contains(text(),'History')]");
+			WebElement historyButton = findElByXPath("//button[contains(text(),'History')]");
 			waitForElement(historyButton);
 			scrollTo(historyButton);
 			historyButton.click();

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/InitiatorsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/InitiatorsTestIT.java
@@ -201,7 +201,7 @@ public class InitiatorsTestIT extends WebTestUtil {
 			waitForElementID("processes-table");
 
 			log.info("Clicking on Test Initiators Page history.");
-			WebElement historyButton = findElByXPath("//button[contains(text(),'History')]");
+			WebElement historyButton = findElByXPath("//a[contains(text(),'History')]");
 			waitForElement(historyButton);
 			historyButton.sendKeys(Keys.RETURN);
 

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/SnippetsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/SnippetsTestIT.java
@@ -120,7 +120,7 @@ public class SnippetsTestIT extends WebTestUtil {
 			waitForElementID("processes-table");
 
 			log.info("Clicking on Test Snippets Page history.");
-			WebElement historyButton = findElByXPath("//button[contains(text(),'History')]");
+			WebElement historyButton = findElByXPath("//a[contains(text(),'History')]");
 			waitForElement(historyButton);
 			scrollTo(historyButton);
 			historyButton.click();

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/WebTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/WebTestIT.java
@@ -223,8 +223,8 @@ public class WebTestIT extends WebTestUtil {
 			filterSubmit.click();
 			sleep(1000);
 
-			waitForElementXPath("//a[contains(text(),'History')]");
-			WebElement historyButton = driver.findElement(By.xpath("//a[contains(text(),'History')]"));
+			waitForElementXPath("//button[contains(text(),'History')]");
+			WebElement historyButton = driver.findElement(By.xpath("//button[contains(text(),'History')]"));
 			historyButton.click();
 			sleep(1000);
 
@@ -270,8 +270,8 @@ public class WebTestIT extends WebTestUtil {
 			filterSubmit.click();
 			sleep(1000);
 
-			waitForElementXPath("//a[contains(text(),'History')]");
-			WebElement historyButton = driver.findElement(By.xpath("//a[contains(text(),'History')]"));
+			waitForElementXPath("//button[contains(text(),'History')]");
+			WebElement historyButton = driver.findElement(By.xpath("//button[contains(text(),'History')]"));
 			historyButton.click();
 			sleep(1000);
 

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/WebTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/WebTestIT.java
@@ -223,8 +223,8 @@ public class WebTestIT extends WebTestUtil {
 			filterSubmit.click();
 			sleep(1000);
 
-			waitForElementXPath("//button[contains(text(),'History')]");
-			WebElement historyButton = driver.findElement(By.xpath("//button[contains(text(),'History')]"));
+			waitForElementXPath("//a[contains(text(),'History')]");
+			WebElement historyButton = driver.findElement(By.xpath("//a[contains(text(),'History')]"));
 			historyButton.click();
 			sleep(1000);
 
@@ -270,8 +270,8 @@ public class WebTestIT extends WebTestUtil {
 			filterSubmit.click();
 			sleep(1000);
 
-			waitForElementXPath("//button[contains(text(),'History')]");
-			WebElement historyButton = driver.findElement(By.xpath("//button[contains(text(),'History')]"));
+			waitForElementXPath("//a[contains(text(),'History')]");
+			WebElement historyButton = driver.findElement(By.xpath("//a[contains(text(),'History')]"));
 			historyButton.click();
 			sleep(1000);
 

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -329,7 +329,7 @@
 					</div>
 
 					<div class="col-md-12">
-						<input type="button" id="filter-submit-btn" class="btn btn-info pull-right" value="Filter"/>
+						<a id="filter-submit-btn" class="btn btn-info pull-right" href="#">Filter</a>
 					</div>
 			</div>
 			<div id="filters-btn" class="btn btn-warning"><span class="glyphicon glyphicon-filter">
@@ -425,7 +425,7 @@
 
 	});
 
-	$("#filter-submit-btn").click(function(){
+	function getFilterQString() {
 		var params = {};
 		if($("#pd-select").val() != "def"){
 			params.procDefKey = $("#pd-select").val();
@@ -457,8 +457,17 @@
 		}
 		qstring = qstring.substring(0,qstring.length-1);
 		//console.log(encodeURI(qstring));
-		window.location="/${base}/logs" + qstring;
+		return qstring;
+	}
+
+	$("#filter-submit-btn").click(function(e){
+		e.preventDefault();
+		window.location="/${base}/logs" + getFilterQString();
 	});
+
+	$("#filter-submit-btn").on("contextmenu", function(e){
+			$(this).attr("href", "/${base}/logs" + getFilterQString(false));
+		});
 
 	var today = new Date();
 	var todayDate = today.getDate() + "/" + today.getMonth() + "/" + today.getFullYear() ;

--- a/install/cws-ui/processes.ftl
+++ b/install/cws-ui/processes.ftl
@@ -130,7 +130,7 @@
 					</div>
 				<br/>
 				<div class="col-md-12">
-					<input type="button" id="filter-submit-btn" class="btn btn-info pull-right" value="Filter"/>
+					<a id="filter-submit-btn" class="btn btn-info pull-right" href="#">Filter</a>
 				</div>
 			</div>
 
@@ -221,9 +221,13 @@
 			todayHighlight:true
 		});
 		
-		$("#filter-submit-btn").click(function(){
-
+		$("#filter-submit-btn").click(function(e){
+			e.preventDefault();
 			updateLocation(false);
+		});
+
+		$("#filter-submit-btn").on("contextmenu", function(e){
+			$(this).attr("href", "/${base}/processes" + getFilterQString(false));
 		});
 		
 		displayMessage();
@@ -278,7 +282,7 @@
 		}
 	});
 
-	function updateLocation(changeHideSubs) {
+	function getFilterQString(changeHideSubs) {
 		var params = {};
 
 		if($("#pd-select").val() != "def"){
@@ -324,11 +328,14 @@
 		}
 		qstring = qstring.substring(0,qstring.length-1);
 		console.log(encodeURI(qstring));
-		window.location="/${base}/processes" + qstring;
+		return qstring;
+	}
+
+	function updateLocation(changeHideSubs) {
+		window.location="/${base}/processes" + getFilterQString(changeHideSubs);
 	}
 	
 	$("#hide-subprocs-btn").click(function(){
-		
 		updateLocation(true);
 	});
 	

--- a/install/cws-ui/processes.ftl
+++ b/install/cws-ui/processes.ftl
@@ -353,6 +353,8 @@
 	
 		if (procInstId !== '') {
 			window.location = "/${base}/history?procInstId=" + procInstId;
+		} else {
+			return false;
 		}
 	}
 	
@@ -360,6 +362,8 @@
 	
 		if (procInstId !== '') {
 			window.location = "/${base}/processes?superProcInstId=" + procInstId;
+		} else {
+			return false;
 		}
 	}
 	
@@ -406,8 +410,8 @@
 						$("#processes-table").append(
 						"<tr id=\""+i+"\" class=\"tr-"+ res[i].status +"\" procInstId=\"" + procInstId + "\">"+
 							"<td>" + actionTd + "</td>" +
-							"<td><button onclick=\"viewHistory('" + procInstId + "')\" class=\"btn btn-default btn-sm\">History</button></td>" +
-							"<td><button onclick=\"viewSubProcs('" + procInstId + "')\" class=\"btn btn-default btn-sm\">Subprocs</button></td>" +
+							"<td><a onclick=\"viewHistory('" + procInstId + "')\" href=\"/${base}/history?procInstId=" + procInstId + "\" class=\"btn btn-default btn-sm\">History</a></td>" +
+							"<td><a onclick=\"viewSubProcs('" + procInstId + "')\" href=\"/${base}/processes?superProcInstId=" + procInstId + "\" class=\"btn btn-default btn-sm\">Subprocs</a></td>" +
 							"<td id=\"row-" + i + "initiationKey\">"+ (res[i].initiationKey == undefined ? '' : res[i].initiationKey) + "</td>" +
 							"<td>"+ res[i].procDefKey +"</td>"+
 							"<td>"+ (res[i].status == 'incident' ? ("<a href=\""+ incidentUrl +"\" target=\"blank_\">" + procInstId + "</a>") : procInstId) + "</td>" +


### PR DESCRIPTION
This PR alters buttons on some pages to turn them into anchor tags to allow users to use right click -> open in new tab.

Updated buttons:
- History button on Processes page
- Subprocs button on Processes page
- Filter button on Processes page
- Filter button on Logs page

As part of updating the button tags to anchor tags, some tests needed to be updated to reflect that. The following tests have been updated to change the xpath of the "button" to look for an anchor tag:
- HistoryTestIT.java
- WebTestIT.java
- InitiatorsTestIT.java
- SnippetsTestIT.java

Images of right-click menu on these buttons:
<img width="417" alt="Screenshot 2023-06-13 at 12 56 32 PM" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/93a8a2d5-b069-42f2-8ff4-9a2c099bb733">
<img width="310" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/231505ae-6e27-4aa6-b450-072ce436f242">