### PR TITLE
UI - Update history page for clarity and interactability  

### DIFF
--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -1318,6 +1318,21 @@ public class RestService extends MvcCore {
 		log.debug("*** REST CALL *** returning " + numRowsUpdated);
 		return ResponseEntity.ok("{ \"status\" : \"success\", \"message\" : \"Updated " + numRowsUpdated + " rows.\"}");
 	}
+
+	@RequestMapping(value = "/process/markResolved/{procInstId}", method = POST)
+	public @ResponseBody ResponseEntity<String> markIndividualResolved(
+			final HttpSession session,
+			@PathVariable String procInstId) {
+		log.info("*** REST CALL *** /process/MarkResolved ... 1");
+
+		try {
+			schedulerDbService.makeResolved(procInstId);
+		} catch (Exception e) {
+			log.error("Problem while marking procInstId as resolved in DB", e);
+		}
+		log.debug("*** REST CALL *** returning");
+		return ResponseEntity.ok("{ \"status\" : \"success\", \"message\" : \"Updated " + procInstId + ".\"}");
+	}
 	
 	
 	/**

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -1120,7 +1120,20 @@ public class RestService extends MvcCore {
 		}
 		return size;
 	}
-	
+
+	@RequestMapping(value="/history/getStatus/{procInstId}", method = GET)
+	public @ResponseBody String getStatusByProcInstId(
+			@PathVariable String procInstId) {
+		List<CwsProcessInstance> instances = null;
+		instances = cwsConsoleService.getFilteredProcessInstancesCamunda(
+				null, procInstId, null, null, null, null, "DESC", 1);
+		if (instances.size() == 0) {
+			return null;
+		} else {
+			return instances.get(0).getStatus();
+		}
+	}
+
 	
 	/**
 	 * REST method used to get Processes table JSON

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -1318,22 +1318,6 @@ public class RestService extends MvcCore {
 		log.debug("*** REST CALL *** returning " + numRowsUpdated);
 		return ResponseEntity.ok("{ \"status\" : \"success\", \"message\" : \"Updated " + numRowsUpdated + " rows.\"}");
 	}
-
-	@RequestMapping(value = "/process/markResolved/{procInstId}", method = POST)
-	public @ResponseBody ResponseEntity<String> markIndividualResolved(
-			final HttpSession session,
-			@PathVariable String procInstId) {
-		log.info("*** REST CALL *** /process/MarkResolved ... 1");
-
-		try {
-			schedulerDbService.makeResolved(procInstId);
-		} catch (Exception e) {
-			log.error("Problem while marking procInstId as resolved in DB", e);
-		}
-		log.debug("*** REST CALL *** returning");
-		return ResponseEntity.ok("{ \"status\" : \"success\", \"message\" : \"Updated " + procInstId + ".\"}");
-	}
-	
 	
 	/**
 	 * 

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/ProcessesTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/ProcessesTestIT.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -63,38 +64,35 @@ public class ProcessesTestIT extends WebTestUtil {
 			log.info("------ START ProcessesTestIT:runStatusCompleteTest ------");
 
 			goToPage("processes");
-			
+
 			log.info("Getting info from table...");
 			wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.tagName("table")));
 			WebElement myTable = driver.findElement(By.tagName("table"));
 			wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.tagName("tr")));
 			List<WebElement> myRows = myTable.findElements(By.tagName("tr"));
-			
+
+			sleep(8000);
+
 			log.info("Locating Test Processes Page from table rows and verifying that it completed.");
-			for (int i = 0; i < myRows.size(); i++) {
-				String row  = myRows.get(i).getText();
-				log.info(row);
-				
-				if (row.contains("test_processes_page")) {
-					log.info("Success, found proc def!");
-					
-					wait.until(ExpectedConditions.visibilityOfElementLocated(By.xpath("id('processes-table')/tbody/tr[\"+i+\"]")));
-					//Looking at row index for test_proccesses_page and checking for a complete status
-					String status = driver.findElement(By.xpath("id('processes-table')/tbody/tr["+i+"]")).getText();
-					
-					if (status.contains("complete")) {
-						log.info("Found status complete for procDef");
-						scriptPass = true;
-						testCasesCompleted++;
-						break;
-					} else {
-						log.info("Fail.");
-						scriptPass = false;
-					}
-				}
-			}	
+			waitForElementXPath("//div[@id=\'processes-table_filter\']/label/input");
+
+			driver.findElement(By.xpath("//div[@id=\'processes-table_filter\']/label/input")).click();
+			driver.findElement(By.xpath("//div[@id=\'processes-table_filter\']/label/input")).sendKeys("test_snippets_page");
+			driver.findElement(By.xpath("//div[@id=\'processes-table_filter\']/label/input")).sendKeys(Keys.ENTER);
+
+			waitForElementID("processes-table");
+			//selenium: check if "test_processes_page" is on the page
+			if (findOnPage("test_processes_page") && findOnPage("complete")) {
+				log.info("Success, found proc def!");
+				log.info("Found status complete for procDef");
+				scriptPass = true;
+				testCasesCompleted++;
+			} else {
+				log.info("Fail.");
+				scriptPass = false;
+			}
 			log.info("------ END ProcessesTestIT:runStatusCompleteTest:runStatusCompleteTest ------");
-		} 
+		}
 		catch (Throwable e) {
 			System.out.println(e.toString());
 			scriptPass = false;

--- a/install/cws-ui/history.ftl
+++ b/install/cws-ui/history.ftl
@@ -214,16 +214,63 @@
 				$('#procDuration').html(convertMillis(data.duration));
 			}
 			
-			var status = data.state;
-			
-			if (data.state === "COMPLETED") {
-				status = "Complete";
+			$.ajax({
+			type: "GET",
+			url: "/${base}/rest/history/getStatus/" + data.procInstId,
+			success: function(data) {
+				var status = data;
+				switch (data) {
+					case "pending":
+						status = "Pending";
+						$("#procStatus").css("color", "blue");
+						break;
+					case "disabled":
+						status = "<b>Disabled</b>";
+						$("#procStatus").css("color", "red");
+						break;
+					case "failedToSchedule":
+						status = "<b>Failed to schedule</b>";
+						$("#procStatus").css("color", "red");
+						break;
+					case "claimedByWorker":
+						status = "Claimed by Worker";
+						$("#procStatus").css("color", "blue");
+						break;
+					case "failedToStart":
+						status = "<b>Failed to start</b>";
+						$("#procStatus").css("color", "red");
+						break;
+					case "running":
+						status = "Running";
+						$("#procStatus").css("color", "blue");
+						break;
+					case "complete":
+						status = "Complete";
+						$("#procStatus").css("color", "green");
+						break;
+					case "resolved":
+						status = "Resolved";
+						$("#procStatus").css("color", "green");
+						break;
+					case "fail":
+						status = "<b>Failed</b>";
+						$("#procStatus").css("color", "red");
+						break;
+					case "incident":
+						status = "<b>Incident</b>";
+						$("#procStatus").css("color", "red");
+						break;
+					default:
+						status = "<b>Unknown</b>";
+						$("#procStatus").css("color", "red");
+						break;
+				}
+				$('#procStatus').html(status);
+			},
+			error: function(e) {
+				$("procStatus").html("Error fetching status - please try again later.");
 			}
-			else if (data.state === "ACTIVE") {
-				status = "Running";
-			}
-			
-			$('#procStatus').html(status);
+			});
 		}
 		
 		return tableRows;
@@ -512,7 +559,7 @@
 						<td style="font-weight:bold;">Duration</td><td id="procDuration">N/A</td>
 					</tr>
 					<tr>
-						<td style="font-weight:bold;">Status</td><td id="procStatus">Unknown</td>
+						<td style="font-weight:bold;">Status</td><td id="procStatus"></td>
 					</tr>
 				</table>
 		</div>

--- a/install/cws-ui/history.ftl
+++ b/install/cws-ui/history.ftl
@@ -277,10 +277,18 @@
 						break;
 				}
 				$('#procStatus').html(status);
-				if ($("#procStatus").text() !== "Failed" && $("#procStatus").text() !== "Failed to start" && $("#procStatus").text() !== "Failed to schedule") {
-					$("#resolveButtonDiv").hide();
-				} else {
+				if ($("#procStatus").text() == "Failed") {
 					$("#resolveButtonDiv").show();
+					$("#resolveButton").show();
+					$("#retryIncidentButton").hide();
+				} else if ($("#procStatus").text() == "Incident") {
+					$("#resolveButtonDiv").show();
+					$("#retryIncidentButton").show();
+					$("#resolveButton").hide();
+				} else {
+					$("#resolveButtonDiv").hide();
+					$("#resolveButton").hide();
+					$("#retryIncidentButton").hide();
 				}
 			},
 			error: function(e) {
@@ -483,17 +491,41 @@
 		);
 	}
 
-	function markAsResolved(procInstId) {
+	function retryIncident(procInstId) {
+		var idArr = [procInstId];
 		$.ajax({
 			type: "POST",
-			url: "/${base}/rest/process/markResolved/" + procInstId,
+			url: "/${base}/rest/processes/retryIncidentRows",
+			Accept : "application/json",
+			contentType: "application/json",
+			dataType: "json",
+			data: JSON.stringify(idArr),
 		})
 		.done(function(msg) {
-			$("#action_msg").html(msg.message);
+			console.log(msg);
 			location.reload();
 		})
 		.fail(function(xhr, err) {
-			$("#action_msg").html(xhr.responseTextmsg.message);
+			console.err(msg);
+		});
+	}
+
+	function markAsResolved(procInstId) {
+		var idArr = [procInstId];
+		$.ajax({
+			type: "POST",
+			url: "/${base}/rest/processes/markResolved",
+			Accept : "application/json",
+			contentType: "application/json",
+			dataType: "json",
+			data: JSON.stringify(idArr),
+		})
+		.done(function(msg) {
+			console.log(msg);
+			location.reload();
+		})
+		.fail(function(xhr, err) {
+			console.err(xhr.responseTextmsg.message);
 		});
 	}
 	
@@ -654,6 +686,7 @@
 		</div>
       <div id="resolveButtonDiv" class="row" style="text-align: center; display: none;">
         <button id="resolveButton" class="btn btn-primary" type="button" onclick="markAsResolved($('#procInstId').text())">Mark as Resolved</button>
+		<button id="retryIncidentButton" class="btn btn-primary" type="button" onclick="retryIncident($('#procInstId').text())">Retry Incident</button>
       </div>
 		</div>
 	

--- a/install/cws-ui/history.ftl
+++ b/install/cws-ui/history.ftl
@@ -13,6 +13,10 @@
 	<script src="/${base}/js/DataTables/datatables.js"></script>
 	<!-- Custom styles for this template -->
 	<link href="/${base}/css/dashboard.css" rel="stylesheet">
+	<style>
+		.dataTables_wrapper .filter .dataTables_filter{float:right; padding-top: 15px; display: inline;}
+		.dataTables_wrapper .download-button {padding-top: 15px;}
+	</style>
 	<script>
 
 	//STATE PERSISTANCE VARS
@@ -266,6 +270,11 @@
 						break;
 				}
 				$('#procStatus').html(status);
+				if ($("#procStatus").text() !== "Failed" && $("#procStatus").text() !== "Failed to start" && $("#procStatus").text() !== "Failed to schedule") {
+					$("#resolveButtonDiv").hide();
+				} else {
+					$("#resolveButtonDiv").show();
+				}
 			},
 			error: function(e) {
 				$("procStatus").html("Error fetching status - please try again later.");
@@ -454,13 +463,38 @@
 			$("#procInstId").text() + '.json'
 		);
 	}
+
+	function markAsResolved(procInstId) {
+		$.ajax({
+			type: "POST",
+			url: "/${base}/rest/process/markResolved/" + procInstId,
+		})
+		.done(function(msg) {
+			$("#action_msg").html(msg.message);
+			location.reload();
+		})
+		.fail(function(xhr, err) {
+			$("#action_msg").html(xhr.responseTextmsg.message);
+		});
+	}
 	
 	$( document ).ready(function() {
 
 		$("#logData").DataTable({
 			order: [[0, 'desc']],
-			paging: false
+			paging: false,
+			dom: "<'row'<'col-sm-2 download-button'><'col-sm-10 filter'f>>" + "tip",
 		});
+
+		$('<div class="dropdown" style="display:inline;">'
+			+ '<button id="downloadButton" class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">&nbsp;Download &nbsp;'
+			+ '<span class="caret"></span>'
+			+ '</button>'
+			+ '<ul id="action-list" class="dropdown-menu" role="menu" aria-labelledby="menu3">'
+			+ '<li id="action_download_json" class="enabled" role="presentation"><a id="json-bttn" role="menuitem" href="#">Download as JSON</a></li>'
+			+ '<li id="action_download_csv" class="enabled" role="presentation"><a id="csv-bttn" role="menuitem" href="#">Download as CSV</a></li>'
+  			+ '</ul>'
+  			+ '</div>').appendTo(".download-button");
 
 		// Get query string values
 		params = getQueryString();
@@ -563,17 +597,8 @@
 					</tr>
 				</table>
 		</div>
-
-		<div class="col-md-12">
-				<div class="dropdown" style="display:inline;">
-				<button id="downloadButton" class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown">&nbsp;Download &nbsp;
-					<span class="caret"></span>
-				</button>
-				<ul id="action-list" class="dropdown-menu" role="menu" aria-labelledby="menu3">
-					<li id="action_download_json" class="enabled" role="presentation"><a id="json-bttn" role="menuitem" href="#">Download as JSON</a></li>
-					<li id="action_download_csv" class="enabled" role="presentation"><a id="csv-bttn" role="menuitem" href="#">Download as CSV</a></li>
-  				</ul>
-  			</div>
+		<div id="resolveButtonDiv" class="row" style="text-align: center; display: none;">
+			<button id="resolveButton" class="btn btn-primary" type="button" onclick="markAsResolved($('#procInstId').text())">Mark as Resolved</button>
 		</div>
 		<!--
 			<div class="col-sm-12 main">


### PR DESCRIPTION
This PR updates the History page and implements the following "tickets":

- "Show actual status and not just 'Running/Complete'" - The history page now features more detailed status descriptors which automatically change color based on their values. 
<img width="952" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/0f85f1d7-155b-4d4f-94e4-1ab16d5425c8">
<img width="886" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/06e4b7ea-8567-4a74-8edb-829f8c72221c">
<img width="871" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/aeac3922-1cd6-42c8-8cc4-321442225757">

- "Add Button to 'Resolve Failure'" - The history page now has features a button (which only displays when the status is "Failed", "Failed to start", and "Failed to schedule"). The button allows for users to mark individual processes as "Resolved"
<img width="902" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/964e64b9-829f-4afc-9626-6f9a3d1bc028">
<img width="906" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/7f56ce26-b525-433b-837f-25346f8113ad">
