### PR TITLE
UI - Update logs to use DataTables

### DIFF
--- a/.github/workflows/camunda.yml
+++ b/.github/workflows/camunda.yml
@@ -113,6 +113,7 @@ jobs:
           path: test-screenshots/
           
       - name: Upload logs
+        if: ${{ always() && steps.build.outcome == 'success' }}
         uses: actions/upload-artifact@v3
         with:
           name: logs

--- a/cws-core/src/main/java/jpl/cws/core/db/SchedulerDbService.java
+++ b/cws-core/src/main/java/jpl/cws/core/db/SchedulerDbService.java
@@ -531,6 +531,10 @@ public class SchedulerDbService extends DbService implements InitializingBean {
         );
     }
 
+    public List<Map<String,Object>> getWorkerIds() {
+        return jdbcTemplate.queryForList("SELECT id FROM cws_worker ORDER BY id");
+    }
+
     public List<Map<String, Object>> getWorkers() {
         return jdbcTemplate.queryForList(
                 "SELECT * FROM cws_worker ORDER BY name");
@@ -881,6 +885,32 @@ public class SchedulerDbService extends DbService implements InitializingBean {
         log.trace("cwsRowsCount = " + cwsRowsCount + ", camundaRowsCount = " + camundaRowsCount);
 
         return cwsRowsCount + camundaRowsCount;
+    }
+
+    /**
+     * Returns the list of process instance IDs
+     */
+
+    public List<String> getAllProcInsts() {
+        String cwsQuery = "SELECT proc_inst_id FROM cws_sched_worker_proc_inst WHERE proc_inst_id IS NOT NULL;";
+        List<Map<String, Object>> cwsRows = jdbcTemplate.queryForList(cwsQuery);
+
+        String camundaQuery = "SELECT PI.proc_inst_id AS proc_inst_id FROM cws_proc_inst_status PI LEFT JOIN cws_sched_worker_proc_inst CI ON PI.proc_inst_id = CI.proc_inst_id WHERE PI.proc_inst_id IS NOT NULL;";
+        List<Map<String, Object>> camundaRows = jdbcTemplate.queryForList(camundaQuery);
+
+        List<String> ret = new ArrayList<String>();
+
+        for (Map<String, Object> cwsRow: cwsRows) {
+            ret.add((String) cwsRow.get("proc_inst_id"));
+        }
+
+        for (Map<String, Object> camundaRow: camundaRows) {
+            if (!ret.contains((String) camundaRow.get("proc_inst_id"))) {
+                ret.add((String) camundaRow.get("proc_inst_id"));
+            }
+        }
+
+        return ret;
     }
 
 

--- a/cws-core/src/main/java/jpl/cws/core/web/WebUtils.java
+++ b/cws-core/src/main/java/jpl/cws/core/web/WebUtils.java
@@ -71,7 +71,7 @@ public class WebUtils {
 	 * 
 	 */
 	public static RestCallResult restCall(String urlString, String method, String data, String cookie, String acceptType, String contentType, Boolean allowInsecureRequests, String username, String password) throws Exception {
-		log.trace("urlString = " + urlString);
+		log.debug("urlString = " + urlString);
 		HttpURLConnection connection = null;
 		try {
 			

--- a/cws-service/src/main/java/jpl/cws/controller/MvcCore.java
+++ b/cws-service/src/main/java/jpl/cws/controller/MvcCore.java
@@ -2,6 +2,7 @@ package jpl.cws.controller;
 import java.util.List;
 import java.util.Set;
 
+import jpl.cws.core.db.SchedulerDbService;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,7 +114,9 @@ public class MvcCore {
 			// Add list of (the latest) process definitions to the model
 			//
 			model.addObject("procDefs", cwsExecutionService.listProcessDefinitions());
-			
+			model.addObject("workerIds", cwsConsoleService.getAllWorkerIds());
+			model.addObject("procInstIds", cwsConsoleService.getProcInstIds());
+
 			log.trace("MODEL for Logs page: "+model.getModel());
 		}
 		catch (Throwable t) {

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -13,6 +13,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -691,18 +692,21 @@ public class RestService extends MvcCore {
 	@RequestMapping(value = "/logs/get/noScroll", method = GET, produces="application/json")
 	public @ResponseBody String getLogsNoScroll(
 			@RequestParam(value = "source") String source) {
-		String urlString = constructElasticsearchUrl("/_search?source=" + source + "&source_content_type=application/json");
+		String urlString = constructElasticsearchUrl("/_search");
 
-		log.debug("REST getLogs query = " + urlString);
+		log.debug("REST logs/get/noScroll query = " + urlString);
 
 		try {
+			//we need to decode source
+			String result = java.net.URLDecoder.decode(source, StandardCharsets.UTF_8.name());
+			log.debug("logs/get/noScroll: result: " + result);
 			RestCallResult restCallResult;
 			if (elasticsearchUseAuth()) {
 				// Authenticated call
-				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8", elasticsearchUsername, elasticsearchPassword);
+				restCallResult = WebUtils.restCall(urlString, "POST", result, null, null, "application/json; charset=utf-8", elasticsearchUsername, elasticsearchPassword);
 			} else {
 				// Unauthenticated call
-				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8");
+				restCallResult = WebUtils.restCall(urlString, "POST", result, null, null, "application/json; charset=utf-8");
 			}
 			if (restCallResult.getResponseCode() != 200) {
 				log.error("Error with /logs/get/noScroll: " + restCallResult.getResponse() + "; " + restCallResult.getResponseMessage());

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -629,7 +629,7 @@ public class RestService extends MvcCore {
 	public @ResponseBody String getLogsScroll(
 			@RequestParam(value = "scrollId") String scrollId) {
 		String urlString = constructElasticsearchUrl("/_search/scroll");
-		String jsonData = "{ \"scroll\" : \"1m\", \"scroll_id\" : \"" + scrollId + "\" }";
+		String jsonData = "{ \"scroll\" : \"10m\", \"scroll_id\" : \"" + scrollId + "\" }";
 
 		log.trace("REST getLogs query = " + urlString);
 		log.trace("REST getLogs jsonData = " + jsonData);

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -687,8 +687,6 @@ public class RestService extends MvcCore {
 		log.debug("REST logs/get/noScroll query = " + urlString);
 
 		try {
-			//we need to decode source
-			log.debug("GET NO SCROLL BEFORE REPLACEMENT: " + source);
 			String result = source;
 
 			log.debug("logs/get/noScroll: result: " + result);

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -629,7 +629,7 @@ public class RestService extends MvcCore {
 	public @ResponseBody String getLogsScroll(
 			@RequestParam(value = "scrollId") String scrollId) {
 		String urlString = constructElasticsearchUrl("/_search/scroll");
-		String jsonData = "{ \"scroll\" : \"10m\", \"scroll_id\" : \"" + scrollId + "\" }";
+		String jsonData = "{ \"scroll\" : \"1m\", \"scroll_id\" : \"" + scrollId + "\" }";
 
 		log.trace("REST getLogs query = " + urlString);
 		log.trace("REST getLogs jsonData = " + jsonData);
@@ -679,6 +679,37 @@ public class RestService extends MvcCore {
 			return restCallResult.getResponse();
 		} catch (Exception e) {
 			log.error("Problem performing REST call to get count of log data (URL=" + urlString + ")", e);
+		}
+
+		return "ERROR";
+	}
+
+	/**
+	 * REST method used to get logs on the logs page (shorter scroll timer)
+	 *
+	 */
+	@RequestMapping(value = "/logs/logs/get", method = GET, produces="application/json")
+	public @ResponseBody String getLogLogs(
+			@RequestParam(value = "source") String source) {
+		String urlString = constructElasticsearchUrl("/_search?source=" + source + "&source_content_type=application/json");
+
+		log.trace("REST getLogLogs query = " + urlString);
+
+		try {
+			RestCallResult restCallResult;
+			if (elasticsearchUseAuth()) {
+				// Authenticated call
+				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8", elasticsearchUsername, elasticsearchPassword);
+			} else {
+				// Unauthenticated call
+				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8");
+			}
+			if (restCallResult.getResponseCode() != 200) {
+				return "ERROR";
+			}
+			return restCallResult.getResponse();
+		} catch (Exception e) {
+			log.error("Problem performing REST call to get log data (URL=" + urlString + ")", e);
 		}
 
 		return "ERROR";

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -691,7 +691,7 @@ public class RestService extends MvcCore {
 	@RequestMapping(value = "/logs/get/noScroll", method = GET, produces="application/json")
 	public @ResponseBody String getLogsNoScroll(
 			@RequestParam(value = "source") String source) {
-		String urlString = constructElasticsearchUrl("/_search?_source=" + source + "&source_content_type=application/json");
+		String urlString = constructElasticsearchUrl("/_search?source=" + source + "&source_content_type=application/json");
 
 		log.debug("REST getLogs query = " + urlString);
 

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -705,7 +705,8 @@ public class RestService extends MvcCore {
 				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8");
 			}
 			if (restCallResult.getResponseCode() != 200) {
-				return "ERROR";
+				log.error("Error with /logs/get/noScroll: " + restCallResult.getResponse() + "; " + restCallResult.getResponseMessage());
+				return "ERROR: " + restCallResult.getResponse() + "; " + restCallResult.getResponseMessage();
 			}
 			return restCallResult.getResponse();
 		} catch (Exception e) {

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -698,7 +698,9 @@ public class RestService extends MvcCore {
 
 		try {
 			//we need to decode source
-			String result = java.net.URLDecoder.decode(source, StandardCharsets.UTF_8.name());
+			String result = source.replaceAll("\\+", "%2b");
+			result = java.net.URLDecoder.decode(source, StandardCharsets.UTF_8.name());
+
 			log.debug("logs/get/noScroll: result: " + result);
 			RestCallResult restCallResult;
 			if (elasticsearchUseAuth()) {

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -705,7 +705,7 @@ public class RestService extends MvcCore {
 				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8");
 			}
 			if (restCallResult.getResponseCode() != 200) {
-				return "ERROR";
+				return "ERROR fetching data: " + restCallResult.getResponse() + ", " + restCallResult.getResponseMessage();
 			}
 			return restCallResult.getResponse();
 		} catch (Exception e) {

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -688,12 +688,12 @@ public class RestService extends MvcCore {
 	 * REST method used to get logs on the logs page (shorter scroll timer)
 	 *
 	 */
-	@RequestMapping(value = "/logs/logs/get", method = GET, produces="application/json")
-	public @ResponseBody String getLogLogs(
+	@RequestMapping(value = "/logs/get/noScroll", method = GET, produces="application/json")
+	public @ResponseBody String getLogsNoScroll(
 			@RequestParam(value = "source") String source) {
-		String urlString = constructElasticsearchUrl("/_search?source=" + source + "&source_content_type=application/json");
+		String urlString = constructElasticsearchUrl("/_search?_source=" + source + "&source_content_type=application/json");
 
-		log.trace("REST getLogLogs query = " + urlString);
+		log.debug("REST getLogs query = " + urlString);
 
 		try {
 			RestCallResult restCallResult;
@@ -705,7 +705,7 @@ public class RestService extends MvcCore {
 				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8");
 			}
 			if (restCallResult.getResponseCode() != 200) {
-				return "ERROR fetching data: " + restCallResult.getResponse() + ", " + restCallResult.getResponseMessage();
+				return "ERROR";
 			}
 			return restCallResult.getResponse();
 		} catch (Exception e) {

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -36,11 +36,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 
+import com.google.gson.*;
 import org.apache.commons.io.IOUtils;
 import org.camunda.bpm.engine.ExternalTaskService;
 import org.camunda.bpm.engine.ManagementService;
 import org.camunda.bpm.engine.RepositoryService;
-import com.google.gson.JsonArray;
 import org.camunda.bpm.engine.repository.ProcessDefinition;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -62,16 +62,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.ModelAndView;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 
 import jpl.cws.core.db.SchedulerDbService;
 import jpl.cws.core.db.SchedulerJob;
@@ -698,7 +688,7 @@ public class RestService extends MvcCore {
 
 		try {
 			//we need to decode source
-			String result = source.replaceAll("\\+", "%2b");
+			String result = source.replaceAll("%2B", "+");
 			result = java.net.URLDecoder.decode(source, StandardCharsets.UTF_8.name());
 
 			log.debug("logs/get/noScroll: result: " + result);

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -688,8 +688,14 @@ public class RestService extends MvcCore {
 
 		try {
 			//we need to decode source
-			String result = source.replaceAll("%2B", "+");
-			result = java.net.URLDecoder.decode(source, StandardCharsets.UTF_8.name());
+			log.debug("GET NO SCROLL BEFORE REPLACEMENT: " + source);
+			String result = java.net.URLDecoder.decode(source, StandardCharsets.UTF_8.name());
+			
+			//get index of 00:00
+			int index = result.indexOf("00:00");
+
+			//replace space in front of 00:00 with +
+			result = result.substring(0, index) + "+" + result.substring(index + 1);
 
 			log.debug("logs/get/noScroll: result: " + result);
 			RestCallResult restCallResult;

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -653,8 +653,37 @@ public class RestService extends MvcCore {
 
 		return "ERROR";
 	}
-	
-	
+
+	/**
+	 * REST method used to get the total number of log rows
+	 *
+	 */
+	@RequestMapping(value="/logs/get/count", method = GET, produces="application/json")
+	public @ResponseBody String getNumLogs() {
+		String urlString = constructElasticsearchUrl("/_count");
+
+		log.trace("REST getNumLogs query = " + urlString);
+
+		try {
+			RestCallResult restCallResult;
+			if (elasticsearchUseAuth()) {
+				// Authenticated call
+				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8", elasticsearchUsername, elasticsearchPassword);
+			} else {
+				// Unauthenticated call
+				restCallResult = WebUtils.restCall(urlString, "GET", null, null, null, "application/json; charset=utf-8");
+			}
+			if (restCallResult.getResponseCode() != 200) {
+				return "ERROR";
+			}
+			return restCallResult.getResponse();
+		} catch (Exception e) {
+			log.error("Problem performing REST call to get count of log data (URL=" + urlString + ")", e);
+		}
+
+		return "ERROR";
+	}
+
 	/**
 	 * REST method used to get logs
 	 * 
@@ -662,7 +691,7 @@ public class RestService extends MvcCore {
 	@RequestMapping(value = "/logs/get", method = GET, produces="application/json")
 	public @ResponseBody String getLogs(
 			@RequestParam(value = "source") String source) {
-		String urlString = constructElasticsearchUrl("/_search?scroll=1m&source=" + source + "&source_content_type=application/json");
+		String urlString = constructElasticsearchUrl("/_search?scroll=5m&source=" + source + "&source_content_type=application/json");
 		
 		log.trace("REST getLogs query = " + urlString);
 		

--- a/cws-service/src/main/java/jpl/cws/controller/RestService.java
+++ b/cws-service/src/main/java/jpl/cws/controller/RestService.java
@@ -689,13 +689,7 @@ public class RestService extends MvcCore {
 		try {
 			//we need to decode source
 			log.debug("GET NO SCROLL BEFORE REPLACEMENT: " + source);
-			String result = java.net.URLDecoder.decode(source, StandardCharsets.UTF_8.name());
-			
-			//get index of 00:00
-			int index = result.indexOf("00:00");
-
-			//replace space in front of 00:00 with +
-			result = result.substring(0, index) + "+" + result.substring(index + 1);
+			String result = source;
 
 			log.debug("logs/get/noScroll: result: " + result);
 			RestCallResult restCallResult;

--- a/cws-service/src/main/java/jpl/cws/service/CwsConsoleService.java
+++ b/cws-service/src/main/java/jpl/cws/service/CwsConsoleService.java
@@ -740,6 +740,16 @@ public class CwsConsoleService {
         return workers;
     }
 
+    public List<String> getAllWorkerIds() {
+        List<Map<String, Object>> workerIds = schedulerDbService.getWorkerIds();
+        List<String> allIds = new ArrayList<String>();
+        for (Map<String, Object> workerId: workerIds) {
+            String id = workerId.get("id").toString();
+            allIds.add(id);
+        }
+        return allIds;
+    }
+
     /**
      *
      */
@@ -1093,6 +1103,10 @@ public class CwsConsoleService {
     public String getProcInstStatusJson(String uuidOrProcInstId) {
         Map<String, Object> data = cwsProcessService.getProcInstStatusMap(uuidOrProcInstId);
         return new GsonBuilder().setPrettyPrinting().create().toJson(data);
+    }
+
+    public List<String> getProcInstIds() {
+        return schedulerDbService.getAllProcInsts();
     }
 
     /**

--- a/cws-test/src/test/java/jpl/cws/test/WebTestUtil.java
+++ b/cws-test/src/test/java/jpl/cws/test/WebTestUtil.java
@@ -220,7 +220,7 @@ public class WebTestUtil {
 	protected void goToPage(String page) {
 		log.info("Navigating to " + page + " page");
 		driver.get("http://"+HOSTNAME+":"+PORT + "/cws-ui/" + page);
-		driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(30));
+		driver.manage().timeouts().pageLoadTimeout(Duration.ofSeconds(60));
 		postLogging(page, "Navigated to ");
 
 	}

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/InitiatorsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/InitiatorsTestIT.java
@@ -197,16 +197,6 @@ public class InitiatorsTestIT extends WebTestUtil {
 			log.info("Filtering results for Test Initiators Page test.");
 			waitForElementXPath("//div[@id=\'processes-table_filter\']/label/input");
 
-			Set<String> logtyp = driver.manage().logs().getAvailableLogTypes();
-			for (String s : logtyp) {
-				log.info("BROWSER: " + logtyp);
-			}
-			LogEntries logEntries = driver.manage().logs().get(LogType.BROWSER);
-			List<LogEntry> lg = logEntries.getAll();
-			for(LogEntry logEntry : lg) {
-				log.info("BROWSER: " + logEntry);
-			}
-
 			driver.findElement(By.xpath("//div[@id=\'processes-table_filter\']/label/input")).click();
 			driver.findElement(By.xpath("//div[@id=\'processes-table_filter\']/label/input")).sendKeys("test_initiators_page");
 			driver.findElement(By.xpath("//div[@id=\'processes-table_filter\']/label/input")).sendKeys(Keys.ENTER);

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -4,10 +4,15 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.List;
+import java.util.Set;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
+import org.openqa.selenium.logging.LogEntries;
+import org.openqa.selenium.logging.LogEntry;
+import org.openqa.selenium.logging.LogType;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -67,6 +72,18 @@ public class LogsTestIT extends WebTestUtil {
 			log.info("------ START LogsTestIT:runOutputTest ------");
 
 			goToPage("logs");
+
+			sleep(5000);
+
+			Set<String> logtyp = driver.manage().logs().getAvailableLogTypes();
+			for (String s : logtyp) {
+				log.error("BROWSER: " + logtyp);
+			}
+			LogEntries logEntries = driver.manage().logs().get(LogType.BROWSER);
+			List<LogEntry> lg = logEntries.getAll();
+			for(LogEntry logEntry : lg) {
+				log.error("BROWSER: " + logEntry);
+			}
 			
 			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
 

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -114,6 +114,7 @@ public class LogsTestIT extends WebTestUtil {
 			goToPage("logs");
 
 			waitForElementXPath("//div[@id='logData_wrapper']/div/div/div/button/span");
+			findElByXPath("//div[@id='logData_wrapper']/div/div/div/button/span");
 
 			log.info("Checking CWS Host.");
 			findElByXPath("//a[contains(text(),'CWS Host')]").click();

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
@@ -75,20 +76,16 @@ public class LogsTestIT extends WebTestUtil {
 			
 			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
 
-			Set<String> logtyp = driver.manage().logs().getAvailableLogTypes();
-			for (String s : logtyp) {
-				log.error("BROWSER: " + logtyp);
-			}
-			LogEntries logEntries = driver.manage().logs().get(LogType.BROWSER);
-			List<LogEntry> lg = logEntries.getAll();
-			for(LogEntry logEntry : lg) {
-				log.error("BROWSER: " + logEntry);
-			}
-
 			driver.findElement(By.xpath("//input[@id='search-text']")).clear();
 			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
 			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 			sleep(3000);
+
+			LogEntries logEntries = driver.manage().logs().get(LogType.BROWSER);
+			for (LogEntry entry : logEntries) {
+				System.out.println(new Date(entry.getTimestamp()) + " " + entry.getLevel() + " " + entry.getMessage());
+				//do something useful with the data
+			}
 
 			if (findOnPage("Graphite")) {
 				log.info("Found Graphite on page.");

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -75,6 +75,9 @@ public class LogsTestIT extends WebTestUtil {
 			
 			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
 
+			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
+			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
+
 			Set<String> logtyp = driver.manage().logs().getAvailableLogTypes();
 			for (String s : logtyp) {
 				log.error("BROWSER: " + logtyp);
@@ -84,9 +87,6 @@ public class LogsTestIT extends WebTestUtil {
 			for(LogEntry logEntry : lg) {
 				log.error("BROWSER: " + logEntry);
 			}
-
-			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
-			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 
 			if (findOnPage("Graphite")
 					&& findOnPage("Command 'ls' exit code: 0")

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -77,12 +77,6 @@ public class LogsTestIT extends WebTestUtil {
 			
 			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
 
-			LogEntries logEntries = driver.manage().logs().get(LogType.BROWSER);
-			for (LogEntry entry : logEntries) {
-				System.out.println(new Date(entry.getTimestamp()) + " " + entry.getLevel() + " " + entry.getMessage());
-				//do something useful with the data
-			}
-
 			if (findOnPage("Graphite")) {
 				log.info("Found Graphite on page.");
 				if (findOnPage("Command 'ls' exit code: 0")) {
@@ -118,35 +112,23 @@ public class LogsTestIT extends WebTestUtil {
 			log.info("------ START LogsTestIT:runTableColumnTest ------");
 			
 			goToPage("logs");
-			
-			waitForElementID("cwshost-chkbox");
+
+			waitForElementXPath("xpath=//div[@id='logData_wrapper']/div/div/div/button/span");
+
 			log.info("Checking CWS Host.");
-			findElById("cwshost-chkbox").click();
+			findElByXPath("xpath=//a[contains(text(),'CWS Host')]").click();
 			sleep(1000);
-			
-			waitForElementID("cwswid-chkbox");
-			log.info("Checking CWS ID.");
-			findElById("cwswid-chkbox").click();
+
+			log.info("Checking CWS Worker ID.");
+			findElByXPath("xpath=//a[contains(text(),'CWS Worker ID')]").click();
 			sleep(1000);
-			
-			waitForElementID("loglvl-chkbox");
-			log.info("Checking Log Level.");
-			findElById("loglvl-chkbox").click();
+
+			log.info("Checking ProcDefKey.");
+			findElByXPath("xpath=//a[contains(text(),'Proc Def Key')]").click();
 			sleep(1000);
-			
-			waitForElementID("thn-chkbox");
-			log.info("Checking Thread Name.");
-			findElById("thn-chkbox").click();
-			sleep(1000);
-			
-			waitForElementID("pdk-chkbox");
-			log.info("Checking Process Definition Key.");
-			findElById("pdk-chkbox").click();
-			sleep(1000);
-			
-			waitForElementID("pid-chkbox");
-			log.info("Checking Process ID.");
-			findElById("pid-chkbox").click();
+
+			log.info("Checking ProcInstId.");
+			findElByXPath("xpath=//a[contains(text(),'Proc Inst ID')]").click();
 			sleep(1000);
 			
 			wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.tagName("table")));

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -117,19 +117,19 @@ public class LogsTestIT extends WebTestUtil {
 			findElByXPath("//div[@id='logData_wrapper']/div/div/div/button/span").click();
 
 			log.info("Checking CWS Host.");
-			findElByXPath("xpath=//a[contains(.,'CWS Host')]").click();
+			findElByXPath("//a[text()='CWS Host']").click();
 			sleep(1000);
 
 			log.info("Checking CWS Worker ID.");
-			findElByXPath("xpath=//a[contains(.,'CWS Worker ID')]").click();
+			findElByXPath("//a[text()='CWS Worker ID']").click();
 			sleep(1000);
 
 			log.info("Checking ProcDefKey.");
-			findElByXPath("xpath=//a[contains(.,'Proc Def Key')]").click();
+			findElByXPath("//a[text()='Proc Def Key']").click();
 			sleep(1000);
 
 			log.info("Checking ProcInstId.");
-			findElByXPath("xpath=//a[contains(.,'Proc Inst ID')]").click();
+			findElByXPath("//a[text()='Proc Inst ID']").click();
 			sleep(1000);
 			
 			wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.tagName("table")));

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -72,8 +72,8 @@ public class LogsTestIT extends WebTestUtil {
 			log.info("------ START LogsTestIT:runOutputTest ------");
 
 			goToPage("logs");
-
-			sleep(5000);
+			
+			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
 
 			Set<String> logtyp = driver.manage().logs().getAvailableLogTypes();
 			for (String s : logtyp) {
@@ -84,8 +84,9 @@ public class LogsTestIT extends WebTestUtil {
 			for(LogEntry logEntry : lg) {
 				log.error("BROWSER: " + logEntry);
 			}
-			
-			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
+
+			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
+			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 
 			if (findOnPage("Graphite")
 					&& findOnPage("Command 'ls' exit code: 0")

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -113,22 +113,22 @@ public class LogsTestIT extends WebTestUtil {
 			
 			goToPage("logs");
 
-			waitForElementXPath("xpath=//div[@id='logData_wrapper']/div/div/div/button/span");
+			waitForElementXPath("//div[@id='logData_wrapper']/div/div/div/button/span");
 
 			log.info("Checking CWS Host.");
-			findElByXPath("xpath=//a[contains(text(),'CWS Host')]").click();
+			findElByXPath("//a[contains(text(),'CWS Host')]").click();
 			sleep(1000);
 
 			log.info("Checking CWS Worker ID.");
-			findElByXPath("xpath=//a[contains(text(),'CWS Worker ID')]").click();
+			findElByXPath("//a[contains(text(),'CWS Worker ID')]").click();
 			sleep(1000);
 
 			log.info("Checking ProcDefKey.");
-			findElByXPath("xpath=//a[contains(text(),'Proc Def Key')]").click();
+			findElByXPath("//a[contains(text(),'Proc Def Key')]").click();
 			sleep(1000);
 
 			log.info("Checking ProcInstId.");
-			findElByXPath("xpath=//a[contains(text(),'Proc Inst ID')]").click();
+			findElByXPath("//a[contains(text(),'Proc Inst ID')]").click();
 			sleep(1000);
 			
 			wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.tagName("table")));

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -85,21 +85,27 @@ public class LogsTestIT extends WebTestUtil {
 				log.error("BROWSER: " + logEntry);
 			}
 
+			driver.findElement(By.xpath("//input[@id='search-text']")).clear();
 			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
 			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 			sleep(3000);
 
 			if (findOnPage("Graphite")) {
+				log.info("Found Graphite on page.");
+				driver.findElement(By.xpath("//input[@id='search-text']")).clear();
 				driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Command 'ls' exit code: 0");
 				driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 				sleep(3000);
 
 				if (findOnPage("Command 'ls' exit code: 0")) {
+					log.info("Found Command 'ls' exit code: 0 on page.");
+					driver.findElement(By.xpath("//input[@id='search-text']")).clear();
 					driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Deployed process definition: 'test_logs_page.bpmn'");
 					driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 					sleep(3000);
 
 					if (findOnPage("Deployed process definition: 'test_logs_page.bpmn'")) {
+						log.info("Found Deployed process definition: 'text_logs_page.bpmn' on page.");
 						scriptPass = true;
 						testCasesCompleted++;
 					} else {

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -117,19 +117,19 @@ public class LogsTestIT extends WebTestUtil {
 			findElByXPath("//div[@id='logData_wrapper']/div/div/div/button/span");
 
 			log.info("Checking CWS Host.");
-			findElByXPath("//a[contains(text(),'CWS Host')]").click();
+			findElByXPath("xpath=//a[contains(.,'CWS Host')]").click();
 			sleep(1000);
 
 			log.info("Checking CWS Worker ID.");
-			findElByXPath("//a[contains(text(),'CWS Worker ID')]").click();
+			findElByXPath("xpath=//a[contains(.,'CWS Worker ID')]").click();
 			sleep(1000);
 
 			log.info("Checking ProcDefKey.");
-			findElByXPath("//a[contains(text(),'Proc Def Key')]").click();
+			findElByXPath("xpath=//a[contains(.,'Proc Def Key')]").click();
 			sleep(1000);
 
 			log.info("Checking ProcInstId.");
-			findElByXPath("//a[contains(text(),'Proc Inst ID')]").click();
+			findElByXPath("xpath=//a[contains(.,'Proc Inst ID')]").click();
 			sleep(1000);
 			
 			wait.until(ExpectedConditions.visibilityOfAllElementsLocatedBy(By.tagName("table")));

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -10,6 +10,7 @@ import java.util.Set;
 
 import org.junit.Test;
 import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.logging.LogEntries;
 import org.openqa.selenium.logging.LogEntry;
@@ -76,7 +77,9 @@ public class LogsTestIT extends WebTestUtil {
 			
 			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
 
-			driver.findElement(By.xpath("//input[@id='search-text']")).clear();
+			for (int i = 0; i < 15; i++) {
+				driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys(Keys.BACK_SPACE);
+			}
 			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
 			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 			sleep(3000);
@@ -89,14 +92,18 @@ public class LogsTestIT extends WebTestUtil {
 
 			if (findOnPage("Graphite")) {
 				log.info("Found Graphite on page.");
-				driver.findElement(By.xpath("//input[@id='search-text']")).clear();
+				for (int i = 0; i < 15; i++) {
+					driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys(Keys.BACK_SPACE);
+				}
 				driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Command 'ls' exit code: 0");
 				driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 				sleep(3000);
 
 				if (findOnPage("Command 'ls' exit code: 0")) {
 					log.info("Found Command 'ls' exit code: 0 on page.");
-					driver.findElement(By.xpath("//input[@id='search-text']")).clear();
+					for (int i = 0; i < 15; i++) {
+						driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys(Keys.BACK_SPACE);
+					}
 					driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Deployed process definition: 'test_logs_page.bpmn'");
 					driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
 					sleep(3000);

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -114,7 +114,7 @@ public class LogsTestIT extends WebTestUtil {
 			goToPage("logs");
 
 			waitForElementXPath("//div[@id='logData_wrapper']/div/div/div/button/span");
-			findElByXPath("//div[@id='logData_wrapper']/div/div/div/button/span");
+			findElByXPath("//div[@id='logData_wrapper']/div/div/div/button/span").click();
 
 			log.info("Checking CWS Host.");
 			findElByXPath("xpath=//a[contains(.,'CWS Host')]").click();

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -77,13 +77,6 @@ public class LogsTestIT extends WebTestUtil {
 			
 			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
 
-			for (int i = 0; i < 15; i++) {
-				driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys(Keys.BACK_SPACE);
-			}
-			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
-			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
-			sleep(3000);
-
 			LogEntries logEntries = driver.manage().logs().get(LogType.BROWSER);
 			for (LogEntry entry : logEntries) {
 				System.out.println(new Date(entry.getTimestamp()) + " " + entry.getLevel() + " " + entry.getMessage());
@@ -92,22 +85,8 @@ public class LogsTestIT extends WebTestUtil {
 
 			if (findOnPage("Graphite")) {
 				log.info("Found Graphite on page.");
-				for (int i = 0; i < 15; i++) {
-					driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys(Keys.BACK_SPACE);
-				}
-				driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Command 'ls' exit code: 0");
-				driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
-				sleep(3000);
-
 				if (findOnPage("Command 'ls' exit code: 0")) {
 					log.info("Found Command 'ls' exit code: 0 on page.");
-					for (int i = 0; i < 15; i++) {
-						driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys(Keys.BACK_SPACE);
-					}
-					driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Deployed process definition: 'test_logs_page.bpmn'");
-					driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
-					sleep(3000);
-
 					if (findOnPage("Deployed process definition: 'test_logs_page.bpmn'")) {
 						log.info("Found Deployed process definition: 'text_logs_page.bpmn' on page.");
 						scriptPass = true;

--- a/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
+++ b/cws-test/src/test/java/jpl/cws/test/integration/ui/LogsTestIT.java
@@ -75,9 +75,6 @@ public class LogsTestIT extends WebTestUtil {
 			
 			log.info("Looking for text, 'Graphite', 'Command ls exit exit code: 0', and 'Deployed process definitions: test_logs_page.bpmn'.");
 
-			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
-			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
-
 			Set<String> logtyp = driver.manage().logs().getAvailableLogTypes();
 			for (String s : logtyp) {
 				log.error("BROWSER: " + logtyp);
@@ -88,14 +85,33 @@ public class LogsTestIT extends WebTestUtil {
 				log.error("BROWSER: " + logEntry);
 			}
 
-			if (findOnPage("Graphite")
-					&& findOnPage("Command 'ls' exit code: 0")
-					&& findOnPage("Deployed process definition: 'test_logs_page.bpmn'")) {
-				scriptPass = true;
-				testCasesCompleted++;
+			driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Graphite");
+			driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
+			sleep(3000);
+
+			if (findOnPage("Graphite")) {
+				driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Command 'ls' exit code: 0");
+				driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
+				sleep(3000);
+
+				if (findOnPage("Command 'ls' exit code: 0")) {
+					driver.findElement(By.xpath("//input[@id='search-text']")).sendKeys("Deployed process definition: 'test_logs_page.bpmn'");
+					driver.findElement(By.xpath("//a[@id='filter-submit-btn']")).click();
+					sleep(3000);
+
+					if (findOnPage("Deployed process definition: 'test_logs_page.bpmn'")) {
+						scriptPass = true;
+						testCasesCompleted++;
+					} else {
+						log.info("\"Deployed process definition: 'test_logs_page.bpmn'\" not found.");
+					}
+				} else {
+					log.info("\"Command 'ls' exit code: 0\" not found.");
+				}
 			} else {
-				log.info("Not found.");
+				log.info("\"Graphite\" not found.");
 			}
+
 			log.info("------ END LogsTestIT:runOutputTest ------");
 		}
 		catch (Throwable e) {

--- a/cws-ui/src/main/webapp/css/dashboard.css
+++ b/cws-ui/src/main/webapp/css/dashboard.css
@@ -352,3 +352,31 @@ div[class*="bar-"]{
   transform: scale(2) translateX(-15%);
   z-index: 6;
 }
+
+.autocomplete {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.autocomplete-items {
+  position: absolute;
+  border: 1px solid #d4d4d4;
+  border-bottom: none;
+  border-top: none;
+  z-index: 99;
+  top: 100%;
+  left: 0;
+  right: 0;
+}
+
+.autocomplete-items div {
+  padding: 10px;
+  cursor: pointer;
+  background-color: #fff; 
+  border-bottom: 1px solid #d4d4d4; 
+}
+
+.autocomplete-items div:hover {
+  background-color: #e9e9e9; 
+}

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -3,7 +3,7 @@
 }
 
 #pd-select {
-    width: 90%;
+    width: 100%;
 }
 
 #log-level-sel {
@@ -62,7 +62,7 @@ tr.debug {
 }
 
 #start-date, #end-date {
-    width: 90%;
+    width: 100%;
 }
 
 .textWrap {

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -1,0 +1,70 @@
+#filters-table td {
+    width: 20%;
+}
+
+#pd-select {
+    width: 90%;
+}
+
+#log-level-sel {
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 5px;
+}
+
+#log-level-sel input {
+    margin-right: 5px
+}
+
+#log-level-sel label {
+    cursor: pointer;
+    font-weight: normal;
+}
+
+#logData {
+    font-size: 95%;
+}
+
+#logData tr th {
+    white-space: nowrap;
+}
+
+/* log level header*/
+#logData tr th:nth-child(5) {
+    padding-right: 25px;
+}
+
+#logData tr td {
+    line-height: 1;
+}
+
+#logData tr td:nth-child(8) {
+    /*overflow: auto;*/
+    word-wrap: break-word;
+    word-break: break-all;
+    font-family: courier, consolas;
+    /*white-space: normal !important;*/
+}
+
+tr.debug {
+    color: #777;
+}
+
+#sh-cols div {
+    display: inline-block;
+    border-right: 1px solid #eee;
+    padding: 4px 15px;
+}
+
+#sh-cols div input, #sh-cols div label {
+    margin-right: 8px;
+    cursor: pointer;
+}
+
+#sh-cols div:last-child {
+    border: none;
+}
+
+#start-date, #end-date {
+    width: 90%;
+}

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -78,9 +78,8 @@ div.dts tbody th, div.dts tbody td {
     flex-direction: row;
     flex-wrap: nowrap;
     justify-content: flex-start;
-    align-items: flex-end;
+    align-items: center;
     gap: 10px;
-    margin-bottom: 5px;
 }
 
 .above-table-buttons {

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -137,6 +137,7 @@ div.dts tbody th, div.dts tbody td {
 #filters-div-flex {
     border: 1px solid #eee;
     margin: 10px auto;
+    margin-right: 15px;
     padding: 10px;
     /*display: none;*/
     overflow: visible;
@@ -149,18 +150,21 @@ div.dts tbody th, div.dts tbody td {
     justify-content: space-around;
     align-items: flex-start;
     gap: 30px;
+    margin-left: 15px;
+    margin-right: 15px;
 }
 
 #filters-div-col-1 {
     flex-grow: 1;
-    max-width: 292px;
+    width: 33%;
 }
 
 #filters-div-col-2 {
     flex-grow: 1;
+    width: 33%;
 }
 
 #filters-div-col-3 {
     flex-grow: 1;
+    width: 33%;
 }
-

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -29,11 +29,6 @@
     font-size: 95%;
 }
 
-/* log level header*/
-#logData tr th:nth-child(5) {
-    padding-right: 25px;
-}
-
 #logData tr td {
     line-height: 1;
 }
@@ -134,4 +129,9 @@ div.dts tbody th, div.dts tbody td {
     justify-content: space-between;
     align-items: center;
     height: 50px;
+}
+
+.scrollTable {
+    overflow-y: auto;
+    clear: both;
 }

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -2,10 +2,6 @@
     width: 20%;
 }
 
-#filters-div {
-    margin-right: 15px;
-}
-
 #pd-select {
     width: 100%;
 }
@@ -137,3 +133,34 @@ div.dts tbody th, div.dts tbody td {
     overflow-y: auto;
     clear: both;
 }
+
+#filters-div-flex {
+    border: 1px solid #eee;
+    margin: 10px auto;
+    padding: 10px;
+    /*display: none;*/
+    overflow: visible;
+}
+
+#filters-div-row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-around;
+    align-items: flex-start;
+    gap: 30px;
+}
+
+#filters-div-col-1 {
+    flex-grow: 1;
+    max-width: 292px;
+}
+
+#filters-div-col-2 {
+    flex-grow: 1;
+}
+
+#filters-div-col-3 {
+    flex-grow: 1;
+}
+

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -180,3 +180,7 @@ div.dts tbody th, div.dts tbody td {
     margin-right: 15px;
     margin-top: 15px;
 }
+
+#logData_info.dataTables_info {
+    padding-top: 0px;
+}

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -25,10 +25,6 @@
     font-size: 95%;
 }
 
-#logData tr th {
-    white-space: nowrap;
-}
-
 /* log level header*/
 #logData tr th:nth-child(5) {
     padding-right: 25px;
@@ -38,7 +34,7 @@
     line-height: 1;
 }
 
-#logData tr td:nth-child(8) {
+.messageStyle {
     /*overflow: auto;*/
     word-wrap: break-word;
     word-break: break-all;
@@ -67,4 +63,63 @@ tr.debug {
 
 #start-date, #end-date {
     width: 90%;
+}
+
+.textWrap {
+    text-wrap: normal;
+}
+
+div.dts tbody th, div.dts tbody td {
+    white-space: normal !important;
+    overflow-wrap: anywhere;
+}
+
+.above-table-div {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    align-items: flex-end;
+    gap: 10px;
+    margin-bottom: 5px;
+}
+
+.above-table-buttons {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    align-items: flex-end;
+    gap: 10px;
+}
+
+.above-table-filter {
+    margin-right: 15px;
+}
+
+.above-table-filler {
+    flex-grow: 1;
+}
+
+.btn-icon {
+    margin-right: 5px;
+}
+
+.below-table-div {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 10px;
+    margin-bottom: 5px;
+}
+
+.dataTables_wrapper .dtsb-titleRow {
+    display: none;
+}
+
+.dataTables_wrapper .dtsb-group {
+    padding-bottom: -15px !important;
+    padding-top: 8px;
 }

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -38,6 +38,9 @@
     word-wrap: break-word;
     word-break: break-all;
     font-family: courier, consolas;
+    height: 50px;
+    overflow-y: auto;
+    margin-bottom: 0px !important;
     /*white-space: normal !important;*/
 }
 

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -168,3 +168,15 @@ div.dts tbody th, div.dts tbody td {
     flex-grow: 1;
     width: 33%;
 }
+
+.filter-div-submit {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 10px;
+    margin-left: 15px;
+    margin-right: 15px;
+    margin-top: 15px;
+}

--- a/cws-ui/src/main/webapp/css/logs.css
+++ b/cws-ui/src/main/webapp/css/logs.css
@@ -2,6 +2,10 @@
     width: 20%;
 }
 
+#filters-div {
+    margin-right: 15px;
+}
+
 #pd-select {
     width: 100%;
 }
@@ -122,4 +126,12 @@ div.dts tbody th, div.dts tbody td {
 .dataTables_wrapper .dtsb-group {
     padding-bottom: -15px !important;
     padding-top: 8px;
+}
+
+#filter-btn-refresh-flexbox {
+    display: flex;
+    flex-wrap: nowrap;
+    justify-content: space-between;
+    align-items: center;
+    height: 50px;
 }

--- a/cws-ui/src/main/webapp/js/cws.js
+++ b/cws-ui/src/main/webapp/js/cws.js
@@ -127,10 +127,10 @@ function removeActive(x) {
     }
 }
 
-function closeAllLists(elmnt) {
+function closeAllLists(elmnt, inp) {
     var x = document.getElementsByClassName("autocomplete-items-cws");
     for (var i = 0; i < x.length; i++) {
-        if (elmnt !== x[i] && elmnt !== inp) {
+        if (elmnt !== x[i]) {
             x[i].parentNode.removeChild(x[i]);
         }
     }

--- a/cws-ui/src/main/webapp/js/cws.js
+++ b/cws-ui/src/main/webapp/js/cws.js
@@ -69,3 +69,69 @@ function checkForURL(potentialURL) {
         return false;
     }
 }
+
+function autocomplete(inp, arr) {
+    var currentFocus;
+    inp.addEventListener("input", function(e) {
+        var a, b, i, val = this.value;
+        closeAllLists();
+        if (!val || val.length < 2) { return false;}
+        currentFocus = -1;
+        a = document.createElement("DIV");
+        a.setAttribute("id", this.id + "autocomplete-list");
+        a.setAttribute("class", "autocomplete-items autocomplete-items-cws");
+        this.parentNode.appendChild(a);
+        for (i = 0; i < arr.length; i++) {
+            if (arr[i].substr(0, val.length).toUpperCase() === val.toUpperCase()) {
+                b = document.createElement("DIV");
+                b.innerHTML = "<strong>" + arr[i].substr(0, val.length) + "</strong>";
+                b.innerHTML += arr[i].substr(val.length);
+                b.innerHTML += "<input type='hidden' value='" + arr[i] + "'>";
+                b.addEventListener("click", function(e) {
+                    inp.value = this.getElementsByTagName("input")[0].value;
+                    closeAllLists();
+                });
+                a.appendChild(b);
+            }
+        }
+    });
+    inp.addEventListener("keydown", function(e) {
+        var x = document.getElementById(this.id + "autocomplete-list");
+        if (x) x = x.getElementsByTagName("div");
+        if (e.keyCode === 40) {
+            currentFocus++;
+            addActive(x);
+        } else if (e.keyCode === 38) {
+            currentFocus--;
+            addActive(x);
+        } else if (e.keyCode === 13) {
+            e.preventDefault();
+            if (currentFocus > -1) {
+                if (x) x[currentFocus].click();
+            }
+        }
+    });
+}
+
+function addActive(x) {
+    if (!x) return false;
+    removeActive(x);
+    if (currentFocus >= x.length) currentFocus = 0;
+    if (currentFocus < 0) currentFocus = (x.length - 1);
+    x[currentFocus].classList.add("autocomplete-active");
+}
+
+function removeActive(x) {
+    for (var i = 0; i < x.length; i++) {
+        x[i].classList.remove("autocomplete-active");
+    }
+}
+
+function closeAllLists(elmnt) {
+    var x = document.getElementsByClassName("autocomplete-items-cws");
+    for (var i = 0; i < x.length; i++) {
+        if (elmnt !== x[i] && elmnt !== inp) {
+            x[i].parentNode.removeChild(x[i]);
+        }
+    }
+}

--- a/install/cws-ui/deployments.ftl
+++ b/install/cws-ui/deployments.ftl
@@ -421,7 +421,7 @@
 				//dom: "<'row'<'col-sm-2 download-button'><'col-sm-10 filter'f>>" + "tip",
 			});
 
-			$('<button id="download-btn" class="btn btn-primary" onclick="downloadJSON()"><i class="glyphicon glyphicon-save btn-icon"></i>Download (JSON)</button>').appendTo(".above-table-buttons");
+			$('<button id="download-btn" class="btn btn-primary" onclick="downloadJSON()"><i class="glyphicon glyphicon-save btn-icon"></i>Download</button>').appendTo(".above-table-buttons");
 
 			refreshStats();
 			pageRefId = setInterval(pageRefresh, parseInt(localStorage.getItem(refreshRateVar)));

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -14,6 +14,7 @@
 	<script src="/${base}/js/bootstrap-datepicker.min.js"></script>
     <script src="/${base}/js/DataTables/dataTables.responsive.min.js"></script>
     <script src="/${base}/js/DataTables/responsive.bootstrap.min.js"></script>
+	<script src="/${base}/js/cws.js" type="text/javascript"></script>
 
 	<!--Load CSS Stylesheets-->
 	<link href="/${base}/css/bootstrap.min.css"rel="stylesheet">
@@ -138,11 +139,14 @@
 		$(document).ready(function(){
 		//show ajax spinner
 		$("#log-div .ajax-spinner").show();
+
+		document.addEventListener("click", function (e) {
+			closeAllLists(e.target);
+		});
 	
 		params = getQueryString();
 
 		mainEsReq = getEsReq();
-
 		//push our timestamp to the esreq
 		mainEsReq.query.bool.must.push({"range": {"@timestamp": {"lte": now}}});
 	
@@ -478,6 +482,9 @@
 	
 			$("#filters-div").slideToggle();
 		});
+
+		autocomplete(document.getElementById("pi-text"), procInstIdArr);
+		autocomplete(document.getElementById("worker-id-text"), workerIdArr);
 	
 		}); //END OF DOCUMENT.READY
 	
@@ -576,9 +583,12 @@
 			</span>
 			
 			<h2 class="sub-header">Logs</h2>
-			<div id="filters-div">
-				<h4>Filters:</h4>
-					<div class="col-md-4">
+			<div id="filters-div-flex">
+				<div id="filters-div-header">
+					<h4>Filters:</h4>
+				</div>
+				<div id="filters-div-row">
+					<div id="filters-div-col-1">
 						<h5>Process Definitions</h5>
 						<select id="pd-select">
 							<option value="def">All Process Definitions</option>
@@ -587,11 +597,15 @@
 							</#list>
 						</select>
 						<h5>Process Instances</h5>
-						<input id="pi-text"type="text"class="form-control"placeholder="Instance ID...">
+						<div class="autocomplete">
+							<input id="pi-text"type="text"class="form-control"placeholder="Instance ID...">
+						</div>
 						<h5>Worker ID</h5>
-						<input id="worker-id-text" type="text" class="form-control" placeholder="Worker ID...">
+						<div class="autocomplete">
+							<input id="worker-id-text" type="text" class="form-control" placeholder="Worker ID...">
+						</div>
 					</div>
-					<div class="col-md-4">
+					<div id="filters-div-col-2">
 						<h5>Log Level</h5>
 						<div id="log-level-sel">
 							<input type='checkbox'id='trace'value='TRACE'/>
@@ -606,20 +620,17 @@
 							<label for='error'>Error</label><br/>
 						</div>
 					</div>
-					<div class="col-md-4">
+					<div id="filters-div-col-3">
 						<h5>Search by Keyword</h5>
 						<input id="search-text"id="filter-text"type="text"class="form-control"placeholder="Search..."/>
 						<h5>Start Date:</h5>
 						<input id="start-date"class="form-control"placeholder="yyyy-mm-dd"
-        					data-date-format="yyyy-mm-dd"maxlength="10"type="text">
+							data-date-format="yyyy-mm-dd"maxlength="10"type="text">
 						<h5>End Date:</h5>
 						<input id="end-date"class="form-control"placeholder="yyyy-mm-dd"
-        					data-date-format="yyyy-mm-dd"size="16"type="text">
+							data-date-format="yyyy-mm-dd"size="16"type="text">
 					</div>
-
-					<div class="col-md-12" style="margin-top: 15px;">
-						<a id="filter-submit-btn"class="btn btn-info pull-right"href="#">Filter</a>
-					</div>
+				</div>
 			</div>
 			<div id="filter-btn-refresh-flexbox">
 				<div id="filters-btn"class="btn btn-warning"><span class="glyphicon glyphicon-filter">
@@ -675,9 +686,6 @@
 		</div><!--modal-content-->
 	</div><!--modal-dialog-->
 </div><!--.modal.fade-->
-
-
-<script type="text/javascript"src="/${base}/js/cws.js"></script>
 
 </body>
 </html>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -364,6 +364,18 @@
 				}
 			],
 		});
+
+		var table = $('#logData').DataTable();
+
+		table.on("draw", function() {
+			$(".messageStyle").each(function(i, obj) {
+				if (obj.scrollHeight > obj.clientHeight) {
+					$(obj).css("resize", "vertical");
+				} else {
+					$(obj).css("resize", "none");
+				}
+			});
+		}); 
 	
 		if(localStorage.getItem(refreshRateVar)===null){
 			localStorage.setItem(refreshRateVar,"10000");

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -220,7 +220,8 @@
 				var returnData;
 				var fetchError = "";
 
-				console.log("ES REQ: " + JSON.stringify(esReq));
+				console.error("DATA: " + JSON.stringify(data));
+				console.error("ESREQ: " + JSON.stringify(esReq));
 
 				$.ajax({
 					url: "/${base}/rest/logs/logs/get?source=" + encodeURIComponent(JSON.stringify(esReq)),
@@ -236,7 +237,7 @@
 					}
 				});
 
-				console.error(JSON.stringify(returnData));
+				console.error("RETURN DATA: " + JSON.stringify(returnData));
 	
 				//we should have our data now. We need to format it for the table
 				var formattedData = [];
@@ -300,6 +301,7 @@
 					"data": formattedData,
 					"error": fetchError
 				}
+				console.error("RETURN OBJ: " + JSON.stringify(returnObj));
 				callback(returnObj);
 			},
 			columns: [

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -214,9 +214,9 @@
 					text: '<i class="glyphicon glyphicon-eye-open btn-icon"></i>Columns',
 				}
 			],
-			dom: "<'above-table-div'<'above-table-buttons'B><'above-table-length'l><'above-table-filler'><'above-table-filter'f>>"
+			dom: "<'above-table-div'<'above-table-buttons'B><'above-table-length'i><'above-table-filler'><'above-table-filter'f>>"
                         + "t"
-                        + "<'below-table-div'ip>",
+                        + "<'below-table-div'p>",
 			ajax: function (data, callback, settings) {
 				//store our draw value
 				var draw = data.draw;

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -237,7 +237,7 @@
 				esReq = esReq.replace(/"/g, "%22");
 
 				$.ajax({
-					url: "/logs/get/noScroll?source=" + esReq,
+					url: "/${base}/rest/logs/get/noScroll?source=" + esReq,
 					type: "GET",
 					async: false,
 					success: function (ajaxData) {

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -115,6 +115,9 @@
 		$(document).ready(function(){
 	
 		params = getQueryString();
+
+		//show ajax spinner
+		$("#log-div .ajax-spinner").show();
 	
 		// DISPLAY MESSAGE AT TOP OF PAGE
 		//
@@ -145,6 +148,10 @@
 			dom: 'Bfrtip',
 			ordering: false,
 			searchBuilder: true,
+			"initComplete": function(settings, json) {
+				//hide ajax spinner
+				$("#log-div .ajax-spinner").hide();
+			},
 			columnDefs: [
 				{
 					targets: [1,2,5,6],
@@ -564,7 +571,7 @@
 			<div id="resultCount"></div>
 			
 			<div id="log-div">
-				<!--<div class="ajax-spinner"></div>-->
+				<div class="ajax-spinner"></div>
 				<table id="logData"class="table table-striped table-bordered sortable" style="width: 100%">
 					<thead>
 						<tr>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -68,35 +68,28 @@
 	
 		//----------------------------
 		function getEsReq(){
-			console.log("getEsReq called");
 			renderFlag=0;
 			htmlTableRows=[];
 			var esReq=baseEsReq;
 			if (params !== undefined && params !== null) {
 				if(params.procDefKey !== undefined && params.procDefKey !== null){
 					esReq.query.bool.must.push({"match":{"procDefKey":params.procDefKey}});
-					console.log("pushing procDefKey: " + params.procDefKey);
 				}
 				if(params.logLevel  !== undefined && params.logLevel !== null){
 					esReq.query.bool.must.push({"match":{"logLevel":params.logLevel}});
-					console.log("pushing logLevel: " + params.logLevel);
 				}
 				if(params.program  !== undefined && params.program !== null){
 					esReq.query.bool.must.push({"match":{"program":params.program}});
-					console.log("pushing program: " + params.program);
 				}
 				if(params.procInstId  !== undefined && params.procInstId !== null){
 					//esReq.query.bool.must.push({"match":{"procInstId" : decodeURIComponent(params.procInstId)}});
 					esReq.query.bool.must.push({"query_string":{"fields":["procInstId"],"query":"\""+decodeURIComponent(params.procInstId)+"\""}});
-					console.log("pushing procInstId: " + params.procInstId);
 				}
 				if(params.search  !== undefined && params.search !== null){
 					esReq.query.bool.must.push({"query_string":{"fields":["msgBody"],"query":decodeURIComponent(params.search)}});
-					console.log("pushing search: " + params.search);
 				}
 				if (params.workerId !== undefined && params.workerId !== null) {
 					esReq.query.bool.must.push({"match":{"cwsWorkerId":params.workerId}});
-					console.log("pushing workerId: " + params.workerId);
 				}
 		
 				var startDate=params.startDate?decodeURIComponent(params.startDate):"";
@@ -140,7 +133,6 @@
 
 		//push our timestamp to the esreq
 		mainEsReq.query.bool.must.push({"range": {"@timestamp": {"lte": now}}});
-		console.log("pushing timestamp: " + now);
 
 		//show ajax spinner
 		$("#log-div .ajax-spinner").show();
@@ -235,7 +227,6 @@
 				var returnData;
 				var fetchError = "";
 
-				console.error("DATA: " + JSON.stringify(data));
 
 				//console.log("STRINGIFIED: " + JSON.stringify(esReq));
 				//console.log("ENCODED: " + encodeURIComponent(JSON.stringify(esReq)));
@@ -244,7 +235,6 @@
 				local_esReq = encodeURIComponent(local_esReq);
 				//sometimes double quotes get left here? replace double quotes with url encoded
 				local_esReq = local_esReq.replace(/"/g, "%22");
-				console.error("ESREQ: " + local_esReq);
 
 				$.ajax({
 					url: "/${base}/rest/logs/get/noScroll",
@@ -253,7 +243,6 @@
 					async: false,
 					success: function (ajaxData) {
 						returnData = ajaxData;
-						console.error("RETURN DATA: " + JSON.stringify(returnData));
 						//we should have our data now. We need to format it for the table
 						var formattedData = [];
 						for (hit in returnData.hits.hits) {
@@ -266,7 +255,7 @@
 								formattedRow["timestamp"] = "";
 							}
 							if (hitData["cwsHost"] !== undefined) {
-								formattedRow["cws_host"] = hitData["host"];
+								formattedRow["cws_host"] = hitData["cwsHost"];
 							} else {
 								formattedRow["cws_host"] = "";
 							}
@@ -562,7 +551,6 @@
 			$("#logData").DataTable().ajax.reload(function(){
 				$("#log-div .ajax-spinner").hide();
 			},false);
-			console.log("refreshing");
 		}
 		
 	</script>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -475,12 +475,12 @@
 		});
 
 		$("#filters-btn").click(function(){
-			if($("#filters-div").is(":visible"))
+			if($("#filters-div-flex").is(":visible"))
 				$("#filter-arrow").removeClass("glyphicon-chevron-up").addClass("glyphicon-chevron-down");
 			else
 				$("#filter-arrow").removeClass("glyphicon-chevron-down").addClass("glyphicon-chevron-up");
 	
-			$("#filters-div").slideToggle();
+			$("#filters-div-flex").slideToggle();
 		});
 
 		autocomplete(document.getElementById("pi-text"), procInstIdArr);

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -226,8 +226,8 @@
 				var returnData;
 				var fetchError = "";
 
-				//console.error("DATA: " + JSON.stringify(data));
-				//console.error("ESREQ: " + JSON.stringify(esReq));
+				console.error("DATA: " + JSON.stringify(data));
+				console.error("ESREQ: " + JSON.stringify(esReq));
 
 				//console.log("STRINGIFIED: " + JSON.stringify(esReq));
 				//console.log("ENCODED: " + encodeURIComponent(JSON.stringify(esReq)));
@@ -243,8 +243,7 @@
 					async: false,
 					success: function (ajaxData) {
 						returnData = ajaxData;
-						//console.error("RETURN DATA: " + JSON.stringify(returnData));
-	
+						console.error("RETURN DATA: " + JSON.stringify(returnData));
 						//we should have our data now. We need to format it for the table
 						var formattedData = [];
 						for (hit in returnData.hits.hits) {

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -220,6 +220,8 @@
 				var returnData;
 				var fetchError = "";
 
+				console.log("ES REQ: " + JSON.stringify(esReq));
+
 				$.ajax({
 					url: "/${base}/rest/logs/logs/get?source=" + encodeURIComponent(JSON.stringify(esReq)),
 					type: "GET",

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -132,6 +132,11 @@
 		}
 	
 		$("#logData").DataTable({
+			language: {
+				searchBuilder: {
+					add: "<i class=\"glyphicon glyphicon-search btn-icon\"></i>Add Local Filter",
+				}
+			},
 			deferRender: true,
 			scroller: {
 				boundaryScale: 0.25,
@@ -142,11 +147,24 @@
 			serverSide: true,
 			searchDelay: 250,
 			dom: 'Bfrtip',
-			autoWidth: false,
+			ordering: false,
+			searchBuilder: true,
 			columnDefs: [
 				{
 					targets: [1,2,5,6],
 					visible: false,
+				},
+				{
+					targets: [0],
+					width: "215px"
+				},
+				{
+					targets: [3],
+					width: "75px"
+				},
+				{
+					targets: [4],
+					width: "150px"
 				}
 			],
 			buttons: [
@@ -157,6 +175,9 @@
 					text: '<i class="glyphicon glyphicon-eye-open btn-icon"></i>Columns',
 				}
 			],
+			dom: "Q<'above-table-div'<'above-table-buttons'B><'above-table-length'l><'above-table-filler'><'above-table-filter'f>>"
+                        + "t"
+                        + "<'below-table-div'ip>",
 			ajax: function (data, callback, settings) {
 				//store our draw value
 				var draw = data.draw;
@@ -343,7 +364,7 @@
 					data: "message",
 					render: function (data, type) {
 						if (type == "display") {
-							return "<p>" + data.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, "<br/>") + "</p>";
+							return "<p class=\"messageStyle\">" + data.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, "<br/>") + "</p>";
 						} else {
 							return data;
 						}
@@ -570,7 +591,7 @@
 			
 			<div id="log-div">
 				<!--<div class="ajax-spinner"></div>-->
-				<table id="logData"class="table table-striped table-bordered sortable">
+				<table id="logData"class="table table-striped table-bordered sortable" style="width: 100%">
 					<thead>
 						<tr>
 							<th>Time Stamp</th>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -46,6 +46,8 @@
 		var renderFlag=0;
 	
 		var now = moment().format("YYYY-MM-DDTHH:mm:ss.SSSSSSZ");
+
+		var refID;
 	
 		var baseEsReq={
 			"from":0,
@@ -353,15 +355,34 @@
 		}
 	
 		$("#refresh-rate").val((parseInt(localStorage.getItem(refreshRateVar))/1000).toString());
-	
-	
-		if(localStorage.getItem(refreshVar)==="1"){
-			$("#refresh-checkbox").prop("checked",true);
-			refreshRate=parseInt(localStorage.getItem(refreshRateVar));
-			refID=setInterval(refreshLogs,refreshRate);
-		} else{
-			$("#refresh-checkbox").prop("checked",false);
+
+		if(localStorage.getItem(refreshVar)===null){
+			localStorage.setItem(refreshVar,"false");
 		}
+
+		if(localStorage.getItem(refreshVar)=="true"){
+			$("#refresh-checkbox").prop("checked",true);
+			refID=setInterval(refreshLogs,parseInt(localStorage.getItem(refreshRateVar)));
+		}
+
+		$("#refresh-rate").change(function(){
+			localStorage.setItem(refreshRateVar,$(this).val()*1000);
+			if($("#refresh-checkbox").is(":checked")){
+				clearInterval(refID);
+				refID=setInterval(refreshLogs,parseInt(localStorage.getItem(refreshRateVar)));
+			}
+		});
+
+		//onchange for checkbox
+		$("#refresh-checkbox").change(function(){
+			if($(this).is(":checked")){
+				localStorage.setItem(refreshVar,"true");
+				refID=setInterval(refreshLogs,parseInt(localStorage.getItem(refreshRateVar)));
+			} else {
+				localStorage.setItem(refreshVar,"false");
+				clearInterval(refID);
+			}
+		});
 	
 		//get our current url
 		var currentUrl=window.location.href;
@@ -470,31 +491,17 @@
 			todayBtn:'true',
 			todayHighlight:true
 		});
-	
-		//
-		// AUTO-REFRESH SETTING
-		//
-		var refID;
-		$("#refresh-checkbox").click(function(){
-			if($(this).prop("checked")){
-				localStorage.setItem(refreshVar,"1");
-				refreshRate=parseInt(localStorage.getItem(refreshRateVar));
-				refreshLogs();
-				refID=setInterval(refreshLogs,refreshRate);
-			} else {
-				localStorage.setItem(refreshVar,"0");
-				clearInterval(refID);
-			}
-		});
-	
-		$("#refresh-rate").on('change',function(){
-			refreshRate=parseInt($(this).val())*1000;
-			localStorage.setItem(refreshRateVar,refreshRate.toString());
-			if($("#refresh-checkbox").prop("checked")){
-				clearInterval(refID);
-				refID=setInterval(refreshLogs,refreshRate);
-			}
-		});
+
+		function refreshLogs(){
+			$("#log-div .ajax-spinner").show();
+			//update timestamp to grab new logs
+			now=moment().format("YYYY-MM-DDTHH:mm:ss.SSSSSSZ");
+			$("#logData").DataTable().ajax.reload(function(){
+				$("#log-div .ajax-spinner").hide();
+			},false);
+			console.log("refreshing");
+		}
+		
 	</script>
 
 </head>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -440,9 +440,7 @@
 		$("#filter-submit-btn").on("contextmenu",function(e){
 			$(this).attr("href","/${base}/logs"+getFilterQString(false));
 		});
-	
-		}); //END OF DOCUMENT.READY
-	
+
 		$("#filters-btn").click(function(){
 			if($("#filters-div").is(":visible"))
 				$("#filter-arrow").removeClass("glyphicon-chevron-up").addClass("glyphicon-chevron-down");
@@ -451,6 +449,8 @@
 	
 			$("#filters-div").slideToggle();
 		});
+	
+		}); //END OF DOCUMENT.READY
 	
 		function getFilterQString(){
 			var params={};

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -44,6 +44,16 @@
 		var FETCH_COUNT=200;
 		var htmlTableRows=[];
 		var renderFlag=0;
+
+		var workerIdArr = [];
+		<#list workerIds as workerId>
+			workerIdArr.push("${workerId}");
+		</#list>
+
+		var procInstIdArr = [];
+		<#list procInstIds as procInstId>
+			procInstIdArr.push("${procInstId}");
+		</#list>
 	
 		var now = moment().format("YYYY-MM-DDTHH:mm:ss.SSSSSSZ");
 
@@ -126,6 +136,8 @@
 		}
 	
 		$(document).ready(function(){
+		//show ajax spinner
+		$("#log-div .ajax-spinner").show();
 	
 		params = getQueryString();
 
@@ -133,9 +145,6 @@
 
 		//push our timestamp to the esreq
 		mainEsReq.query.bool.must.push({"range": {"@timestamp": {"lte": now}}});
-
-		//show ajax spinner
-		$("#log-div .ajax-spinner").show();
 	
 		// DISPLAY MESSAGE AT TOP OF PAGE
 		//
@@ -437,15 +446,8 @@
 			}
 		}
 	
-		//
-		// INITIAL LOG SET
-		//
-		$("#log-div .ajax-spinner").show();
-	
 		//GET query string values
 		params=getQueryString();
-	
-		$("#log-div .ajax-spinner").hide();
 
 		$("#start-date").datepicker({
 			orientation: 'left top',

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -215,7 +215,7 @@
 				
 				//we need to change the esReq to return the requested number of elements
 				esReq.size = data.length;
-				
+
 				var returnData;
 				var fetchError = "";
 
@@ -233,6 +233,7 @@
 					},
 					error: function (jqXHR, textStatus, errorThrown) {
 						fetchError = "Error getting initial data: " + errorThrown;
+						returnData = fetchError;
 					}
 				});
 

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -228,8 +228,16 @@
 				console.error("DATA: " + JSON.stringify(data));
 				console.error("ESREQ: " + JSON.stringify(esReq));
 
+				console.log("STRINGIFIED: " + JSON.stringify(esReq));
+				console.log("ENCODED: " + encodeURIComponent(JSON.stringify(esReq)));
+
+				esReq = JSON.stringify(esReq);
+				esReq = encodeURIComponent(esReq);
+				//sometimes double quotes get left here? replace double quotes with url encoded
+				esReq = esReq.replace(/"/g, "%22");
+
 				$.ajax({
-					url: "/${base}/rest/logs/logs/get?source=" + encodeURIComponent(JSON.stringify(esReq)),
+					url: "/logs/get/noScroll?source=" + encodeURIComponent(JSON.stringify(esReq)),
 					type: "GET",
 					async: false,
 					success: function (ajaxData) {

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -122,6 +122,25 @@
 			}
 			return esReq;
 		}
+
+		function apiTest() {
+			var esReq = getEsReq();
+			esReq = JSON.stringify(esReq);
+			esReq = encodeURIComponent(esReq);
+			console.log("ESREQ: " + esReq);
+			$.ajax({
+					url: "/${base}/rest/logs/get/noScroll",
+					data: "source=" + esReq,
+					type: "GET",
+					async: false,
+					success: function (ajaxData) {
+						console.log("SUCCESS: " + JSON.stringify(ajaxData));
+					},
+					error: function (jqXHR, textStatus, errorThrown) {
+						console.log("ERROR: " + errorThrown);
+					}
+			});
+		}
 	
 		$(document).ready(function(){
 	
@@ -227,7 +246,6 @@
 				var fetchError = "";
 
 				console.error("DATA: " + JSON.stringify(data));
-				console.error("ESREQ: " + JSON.stringify(esReq));
 
 				//console.log("STRINGIFIED: " + JSON.stringify(esReq));
 				//console.log("ENCODED: " + encodeURIComponent(JSON.stringify(esReq)));
@@ -236,10 +254,11 @@
 				esReq = encodeURIComponent(esReq);
 				//sometimes double quotes get left here? replace double quotes with url encoded
 				esReq = esReq.replace(/"/g, "%22");
+				console.error("ESREQ: " + esReq);
 
 				$.ajax({
 					url: "/${base}/rest/logs/get/noScroll",
-					data: esReq,
+					data: "source=" + esReq,
 					type: "GET",
 					async: false,
 					success: function (ajaxData) {

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -153,7 +153,6 @@
 			searchDelay: 250,
 			dom: 'Bfrtip',
 			ordering: false,
-			searchBuilder: true,
 			"initComplete": function(settings, json) {
 				//hide ajax spinner
 				$("#log-div .ajax-spinner").hide();
@@ -184,7 +183,7 @@
 					text: '<i class="glyphicon glyphicon-eye-open btn-icon"></i>Columns',
 				}
 			],
-			dom: "Q<'above-table-div'<'above-table-buttons'B><'above-table-length'l><'above-table-filler'><'above-table-filter'f>>"
+			dom: "<'above-table-div'<'above-table-buttons'B><'above-table-length'l><'above-table-filler'><'above-table-filter'f>>"
                         + "t"
                         + "<'below-table-div'ip>",
 			ajax: function (data, callback, settings) {
@@ -216,7 +215,7 @@
 				
 				//we need to change the esReq to return the requested number of elements
 				esReq.size = data.length;
-	
+				
 				var returnData;
 				var fetchError = "";
 

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -115,7 +115,16 @@
 		}
 	}
 
-	$("#logData").DataTable();
+	$("#logData").DataTable({
+		deferRender: true,
+		ordering: true,
+		paging: true,
+		searching: true,
+		scroller: true,
+		ajax: function (data, callback, settings) {
+			
+		}
+	});
 
 	if(localStorage.getItem(refreshRateVar)===null){
 		localStorage.setItem(refreshRateVar,"10000");
@@ -257,18 +266,20 @@
 			<div id="resultCount"></div>
 			
 			<div id="log-div">
-				<div class="ajax-spinner"></div>
+				<!--<div class="ajax-spinner"></div>-->
 				<table id="logData"class="table table-striped table-bordered sortable"style="width:100%;">
-					<tr>
-						<th>Time Stamp</th>
-						<th>CWS Host</th>
-						<th>CWS Worker ID</th>
-						<th>Log Level</th>
-						<th>Thread Name</th>
-						<th>Proc Def Key</th>
-						<th>Proc Inst ID</th>
-						<th>Message</th>
-					</tr>
+					<thead>
+						<tr>
+							<th>Time Stamp</th>
+							<th>CWS Host</th>
+							<th>CWS Worker ID</th>
+							<th>Log Level</th>
+							<th>Thread Name</th>
+							<th>Proc Def Key</th>
+							<th>Proc Inst ID</th>
+							<th>Message</th>
+						</tr>
+					</thead>
 				</table>
 			</div>
 		</div>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -233,6 +233,8 @@
 						fetchError = "Error getting initial data: " + errorThrown;
 					}
 				});
+
+				console.log(JSON.stringify(returnData));
 	
 				//we should have our data now. We need to format it for the table
 				var formattedData = [];

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -223,7 +223,8 @@
 				console.error("ESREQ: " + JSON.stringify(esReq));
 
 				$.ajax({
-					url: "/${base}/rest/logs/logs/get?source=" + encodeURIComponent(JSON.stringify(esReq)),
+					url: "/${base}/rest/logs/logs/get",
+					data: "source=" + encodeURIComponent(JSON.stringify(esReq)),
 					type: "GET",
 					contentType: "application/json",
 					async: false,

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -133,9 +133,30 @@
 	
 		$("#logData").DataTable({
 			deferRender: true,
-			scroller: true,
+			scroller: {
+				boundaryScale: 0.25,
+				displayBuffer: 20,
+				loadingIndicator: true,
+			},
 			scrollY: 600,
 			serverSide: true,
+			searchDelay: 250,
+			dom: 'Bfrtip',
+			autoWidth: false,
+			columnDefs: [
+				{
+					targets: [1,2,5,6],
+					visible: false,
+				}
+			],
+			buttons: [
+				{
+					extend: 'colvis',
+					columns: ':not(.noVis)',
+					className: 'btn btn-primary',
+					text: '<i class="glyphicon glyphicon-eye-open btn-icon"></i>Columns',
+				}
+			],
 			ajax: function (data, callback, settings) {
 				//store our draw value
 				var draw = data.draw;

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -236,7 +236,7 @@
 					}
 				});
 
-				console.log(JSON.stringify(returnData));
+				console.error(JSON.stringify(returnData));
 	
 				//we should have our data now. We need to format it for the table
 				var formattedData = [];

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -237,7 +237,7 @@
 				esReq = esReq.replace(/"/g, "%22");
 
 				$.ajax({
-					url: "/logs/get/noScroll?source=" + encodeURIComponent(JSON.stringify(esReq)),
+					url: "/logs/get/noScroll?source=" + esReq,
 					type: "GET",
 					async: false,
 					success: function (ajaxData) {

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -21,161 +21,6 @@
 	<link href="/${base}/js/DataTables/datatables.css"rel="stylesheet">
 	<link href="/${base}/css/dashboard.css"rel="stylesheet">
 	<link href="/${base}/css/logs.css"rel="stylesheet">
-
-	<!--JavaScript-->
-	<script>
-
-	//STATE PERSISTANCE CONSTS
-	const username="username"; //temporary, hardcoded value for now
-	const refreshRateVar="CWS_DASH_LOGS_REFRESH_RATE-"+username;
-	const refreshVar="CWS_DASH_LOGS_REFRESH-"+username;
-	const qstringVar="CWS_DASH_LOGS_QSTRING-"+username;
-
-	// Global vars
-	var params;
-	var FETCH_COUNT=200;
-	var htmlTableRows=[];
-	var renderFlag=0;
-
-	var baseEsReq={
-		"from":0,
-		"size":FETCH_COUNT,
-		"query":{
-			"bool":{
-				"must":[]
-			}
-		},
-		"sort":{
-			"@timestamp":{
-				"order":"desc"
-			}
-		}
-	};
-
-	//----------------------------
-	function fetchInitialLogs(){
-		renderFlag=0;
-		htmlTableRows=[];
-		var esReq=baseEsReq;
-
-		if(params.procDefKey){
-			esReq.query.bool.must.push({"match":{"procDefKey":params.procDefKey}});
-		}
-		if(params.logLevel){
-			esReq.query.bool.must.push({"match":{"logLevel":params.logLevel}});
-		}
-		if(params.program){
-			esReq.query.bool.must.push({"match":{"program":params.program}});
-		}
-		if(params.procInstId){
-			//esReq.query.bool.must.push({"match":{"procInstId" : decodeURIComponent(params.procInstId)}});
-			esReq.query.bool.must.push({"query_string":{"fields":["procInstId"],"query":"\""+decodeURIComponent(params.procInstId)+"\""}});
-		}
-		if(params.search){
-			esReq.query.bool.must.push({"query_string":{"fields":["msgBody"],"query":decodeURIComponent(params.search)}});
-		}
-
-		var startDate=params.startDate?decodeURIComponent(params.startDate):"";
-		var endDate=params.endDate?decodeURIComponent(params.endDate):"";
-
-		if(startDate!=""){
-			//esReq.query.range["@timestamp"].gte = startDate;
-			esReq.query.bool.must.push({"range":{"@timestamp":{"gte":startDate}}});
-		}
-		if(endDate!=""){
-			//esReq.query.range["@timestamp"].lte = endDate;
-			esReq.query.bool.must.push({"range":{"@timestamp":{"lte":endDate}}});
-		}
-
-		$("#pd-select").val(params.procDefKey||"def");
-		//$("#level-select").val(params.logLevel || "def");
-		if(params.logLevel){
-			params.logLevel.split(',').forEach(function(lvl){
-				$("#log-level-sel input[value='"+lvl+"']").prop("checked",true);
-			});
-		}
-		$("#pi-text").val(params.procInstId?decodeURIComponent(params.procInstId):"");
-		$("#search-text").val(params.search?decodeURIComponent(params.search):"");
-		$("#start-date").val(startDate);
-		$("#end-date").val(endDate);
-
-		getLogData(esReq);
-	}
-
-	$(document).ready(function(){
-
-	// DISPLAY MESSAGE AT TOP OF PAGE
-	//
-	if($("#statusMessageDiv:contains('ERROR:')").length>=1){
-		$("#statusMessageDiv").css("color","red");
-	} else if($("#statusMessageDiv h2").text()!=""){
-		$("#statusMessageDiv").css("color","green");
-		if($('#statusMessageDiv').html().length>9){
-			$('#statusMessageDiv').fadeOut(5000,"linear");
-		}
-	}
-
-	$("#logData").DataTable({
-		deferRender: true,
-		ordering: true,
-		paging: true,
-		searching: true,
-		scroller: true,
-		ajax: function (data, callback, settings) {
-			
-		}
-	});
-
-	if(localStorage.getItem(refreshRateVar)===null){
-		localStorage.setItem(refreshRateVar,"10000");
-	}
-
-	$("#refresh-rate").val((parseInt(localStorage.getItem(refreshRateVar))/1000).toString());
-
-
-	if(localStorage.getItem(refreshVar)==="1"){
-		$("#refresh-checkbox").prop("checked",true);
-		refreshRate=parseInt(localStorage.getItem(refreshRateVar));
-		refID=setInterval(refreshLogs,refreshRate);
-	} else{
-		$("#refresh-checkbox").prop("checked",false);
-	}
-
-	//get our current url
-	var currentUrl=window.location.href;
-	//get our local storage url
-	var localStorageUrl=localStorage.getItem(qstringVar);
-	//check if a cookie has been stored (indicating we can restore state)
-	if(localStorageUrl!=null){
-		//remove everything before ?
-		currentUrl=currentUrl.substring(currentUrl.indexOf("logs")+4);
-		//compare against what is in local storage
-		if(currentUrl!=localStorageUrl){
-			//if they are different, go to the one in local storage (essentially restoring from last time used)
-			window.location="/${base}/logs"+localStorageUrl;
-		}
-	}
-
-	//
-	// INITIAL LOG SET
-	//
-	$("#log-div .ajax-spinner").show();
-
-	//GET query string values
-	params=getQueryString();
-
-	if(params==null){
-		loadDefaultLog();
-	}
-	else{
-		loadLogsToTable();
-	}
-
-	$("#log-div .ajax-spinner").hide();
-
-	}); //END OF DOCUMENT.READY
-
-	</script>
 	
 	<!--Just for debugging purposes.Don't actually copy this line! -->
 	<!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
@@ -307,6 +152,267 @@
 
 <script type="text/javascript"src="/${base}/js/cws.js"></script>
 <script type="text/javascript">
+
+	//STATE PERSISTANCE CONSTS
+	const username="username"; //temporary, hardcoded value for now
+	const refreshRateVar="CWS_DASH_LOGS_REFRESH_RATE-"+username;
+	const refreshVar="CWS_DASH_LOGS_REFRESH-"+username;
+	const qstringVar="CWS_DASH_LOGS_QSTRING-"+username;
+
+	// Global vars
+	var params;
+	var FETCH_COUNT=200;
+	var htmlTableRows=[];
+	var renderFlag=0;
+
+	var latestScrollId = "";
+
+	var baseEsReq={
+		"from":0,
+		"size":FETCH_COUNT,
+		"query":{
+			"bool":{
+				"must":[]
+			}
+		},
+		"sort":{
+			"@timestamp":{
+				"order":"desc"
+			}
+		}
+	};
+
+	//----------------------------
+	function getEsReq(){
+		renderFlag=0;
+		htmlTableRows=[];
+		var esReq=baseEsReq;
+
+		if(params.procDefKey !== undefined){
+			esReq.query.bool.must.push({"match":{"procDefKey":params.procDefKey}});
+		}
+		if(params.logLevel  !== undefined){
+			esReq.query.bool.must.push({"match":{"logLevel":params.logLevel}});
+		}
+		if(params.program  !== undefined){
+			esReq.query.bool.must.push({"match":{"program":params.program}});
+		}
+		if(params.procInstId  !== undefined){
+			//esReq.query.bool.must.push({"match":{"procInstId" : decodeURIComponent(params.procInstId)}});
+			esReq.query.bool.must.push({"query_string":{"fields":["procInstId"],"query":"\""+decodeURIComponent(params.procInstId)+"\""}});
+		}
+		if(params.search  !== undefined){
+			esReq.query.bool.must.push({"query_string":{"fields":["msgBody"],"query":decodeURIComponent(params.search)}});
+		}
+
+		var startDate=params.startDate?decodeURIComponent(params.startDate):"";
+		var endDate=params.endDate?decodeURIComponent(params.endDate):"";
+
+		if(startDate!=""){
+			//esReq.query.range["@timestamp"].gte = startDate;
+			esReq.query.bool.must.push({"range":{"@timestamp":{"gte":startDate}}});
+		}
+		if(endDate!=""){
+			//esReq.query.range["@timestamp"].lte = endDate;
+			esReq.query.bool.must.push({"range":{"@timestamp":{"lte":endDate}}});
+		}
+
+		$("#pd-select").val(params.procDefKey||"def");
+		//$("#level-select").val(params.logLevel || "def");
+		if(params.logLevel){
+			params.logLevel.split(',').forEach(function(lvl){
+				$("#log-level-sel input[value='"+lvl+"']").prop("checked",true);
+			});
+		}
+		$("#pi-text").val(params.procInstId?decodeURIComponent(params.procInstId):"");
+		$("#search-text").val(params.search?decodeURIComponent(params.search):"");
+		$("#start-date").val(startDate);
+		$("#end-date").val(endDate);
+
+		return esReq;
+	}
+
+	function apiTest() {
+		console.log(getEsReq());
+	}
+
+	$(document).ready(function(){
+
+	params = getQueryString();
+
+	// DISPLAY MESSAGE AT TOP OF PAGE
+	//
+	if($("#statusMessageDiv:contains('ERROR:')").length>=1){
+		$("#statusMessageDiv").css("color","red");
+	} else if($("#statusMessageDiv h2").text()!=""){
+		$("#statusMessageDiv").css("color","green");
+		if($('#statusMessageDiv').html().length>9){
+			$('#statusMessageDiv').fadeOut(5000,"linear");
+		}
+	}
+
+	$("#logData").DataTable({
+		deferRender: true,
+		ordering: true,
+		paging: true,
+		searching: true,
+		scroller: true,
+		serverSide: true,
+		sortable: false,
+		ajax: function (data, callback, settings) {
+			//we are going to emulate some of the functions of serverSide processing here
+			//INPUT:
+			//draw (int): keeps track of ordering of requests, return this value back
+			//start (int): starting index of the data to return
+			//length (int): number of records to return
+			//search (object): search object
+			//search[value] (string): search value
+			//search[regex] (boolean): is the search value a regex? - should always be false (IGNORE)
+			//order (array): array of objects containing ordering information (IGNORE)
+			//order[i][column] (int): column index to order by (IGNORE)
+			//order[i][dir] (string): direction to order by (asc, desc) (IGNORE)
+			//columns (array): array of objects containing column information (IGNORE)
+			//columns[i][data] (string): column data source (IGNORE)
+			//columns[i][name] (string): column name (IGNORE)
+			//columns[i][searchable] (boolean): is the column searchable? (IGNORE)
+			//columns[i][orderable] (boolean): is the column orderable? (IGNORE)
+			//columns[i][search][value] (string): search value for the column (IGNORE)
+			//columns[i][search][regex] (boolean): is the search value a regex? - should always be false (IGNORE)
+
+			//OUTPUT:
+			//draw (int): echo back the draw value
+			//recordsTotal (int): total number of records (not just the ones returned)
+			//recordsFiltered (int): total number of records after filtering
+			//data (array): array of data to display on the page
+			//error (string): error message if there is one
+
+			//store our draw value
+			var draw = data.draw;
+
+			//get total number of records
+			var totalRecords = 0;
+			$.ajax({
+				url: "/${base}/rest/logs/get/count",
+				type: "GET",
+				async: false,
+				success: function (data) {
+					totalRecords = data.count;
+				},
+				error: function (jqXHR, textStatus, errorThrown) {
+					console.log("Error getting total number of records: " + errorThrown);
+				}
+			});
+
+			//get our esReq based off of filters above table
+			var esReq = getEsReq();
+
+			//check if we have a search value. If we do, we need to store it
+			if (data.search.value) {
+				var newSearchValue = data.search.value;
+				//we need to check if our esReq already has a search value
+				if (esReq.query.bool.must !== undefined) {
+					//there is at least one search condition
+					//go through must array and check if there is a query_string already
+					for (var i = 0; i < esReq.query.bool.must.length; i++) {
+						if (esReq.query.bool.must[i].query_string !== undefined) {
+							//we found a query_string, so we need to update it
+							var existingSearchValue = esReq.query.bool.must[i].query_string.query;
+							esReq.query.bool.must[i].query_string.query = "(" + existingSearchValue + ") AND (" + newSearchValue + ")";
+							break;
+						}
+					}
+				}
+			}
+			//we need to change the esReq to return the requested number of elements
+			esReq.size = data.length;
+
+			var returnData;
+
+			//we need to check if we've made a request before (if we have a scrollId)
+			if (latestScrollId === "") {
+				//we haven't made a request for data yet. We need to make one now and store the resulting scrollID for later calls
+				$.ajax({
+					url: "/${base}/rest/logs/get?source=" + encodeURIComponent(JSON.stringify(esReq)),
+					type: "POST",
+					contentType: "application/json",
+					async: false,
+					success: function (data) {
+						latestScrollId = data._scroll_id;
+						returnData = data;
+					},
+					error: function (jqXHR, textStatus, errorThrown) {
+						console.log("Error getting initial data: " + errorThrown);
+					}
+				});
+			} else {
+				//we made a request for data before. We need to make a request using the scrollID
+				$.ajax({
+					url: "/${base}/rest/logs/get/scroll?scrollId=" + latestScrollId,
+					type: "GET",
+					async: false,
+					success: function (data) {
+						latestScrollId = data._scroll_id;
+						returnData = data;
+					},
+					error: function (jqXHR, textStatus, errorThrown) {
+						console.log("Error getting scroll data: " + errorThrown);
+					}
+				});
+			}
+
+			
+		}
+	});
+
+	if(localStorage.getItem(refreshRateVar)===null){
+		localStorage.setItem(refreshRateVar,"10000");
+	}
+
+	$("#refresh-rate").val((parseInt(localStorage.getItem(refreshRateVar))/1000).toString());
+
+
+	if(localStorage.getItem(refreshVar)==="1"){
+		$("#refresh-checkbox").prop("checked",true);
+		refreshRate=parseInt(localStorage.getItem(refreshRateVar));
+		refID=setInterval(refreshLogs,refreshRate);
+	} else{
+		$("#refresh-checkbox").prop("checked",false);
+	}
+
+	//get our current url
+	var currentUrl=window.location.href;
+	//get our local storage url
+	var localStorageUrl=localStorage.getItem(qstringVar);
+	//check if a cookie has been stored (indicating we can restore state)
+	if(localStorageUrl!=null){
+		//remove everything before ?
+		currentUrl=currentUrl.substring(currentUrl.indexOf("logs")+4);
+		//compare against what is in local storage
+		if(currentUrl!=localStorageUrl){
+			//if they are different, go to the one in local storage (essentially restoring from last time used)
+			window.location="/${base}/logs"+localStorageUrl;
+		}
+	}
+
+	//
+	// INITIAL LOG SET
+	//
+	$("#log-div .ajax-spinner").show();
+
+	//GET query string values
+	params=getQueryString();
+
+	if(params==null){
+		loadDefaultLog();
+	}
+	else{
+		loadLogsToTable();
+	}
+
+	$("#log-div .ajax-spinner").hide();
+
+	}); //END OF DOCUMENT.READY
+
 	$("#filters-btn").click(function(){
 		if($("#filters-div").is(":visible"))
 			$("#filter-arrow").removeClass("glyphicon-chevron-up").addClass("glyphicon-chevron-down");

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -56,7 +56,7 @@
 			procInstIdArr.push("${procInstId}");
 		</#list>
 	
-		var now = moment().format("YYYY-MM-DDTHH:mm:ss.SSSSSSZ");
+		var now = moment().format("YYYY-MM-DDTHH:mm:ss.SSSSSS");
 
 		var refID;
 	
@@ -400,6 +400,15 @@
 				}
 			});
 		}); 
+
+		$("#logData_info.dataTables_info").on(change, function() {
+			//if it contains " of 10,000 entries", then display at top of page 
+			if ($("#logData_info.dataTables_info").text().includes(" of 10,000 entries")) {
+				$("#warning-msg").show();
+			} else {
+				$("#warning-msg").hide();
+			}
+		});
 	
 		if(localStorage.getItem(refreshRateVar)===null){
 			localStorage.setItem(refreshRateVar,"10000");
@@ -631,8 +640,9 @@
 							data-date-format="yyyy-mm-dd"size="16"type="text">
 					</div>
 				</div>
-				<div id="filters-div-row" style="justify-content: flex-end !important; margin-top: 15px;">
-					<a id="filter-submit-btn" class="btn btn-info pull-right" href="#">Filter</a>
+				<div class="filter-div-submit">
+					<b style="margin-top: auto; margin-bottom: auto; color: red;" id="warning-msg">Warning: Only the most recent 10,000 entries are displayed. Please narrow your search criteria.</b>
+					<a id="filter-submit-btn" class="btn btn-info" href="#">Filter</a>
 				</div>
 			</div>
 			<div id="filter-btn-refresh-flexbox">

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -181,6 +181,10 @@
 					width: "215px"
 				},
 				{
+					targets: [1],
+					width: "75px"
+				},
+				{
 					targets: [3],
 					width: "75px"
 				},

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -109,6 +109,11 @@
 						$("#log-level-sel input[value='"+lvl+"']").prop("checked",true);
 					});
 				}
+
+				if (esReq.query.bool.must.length == 0) {
+					esReq.query.bool.must.push({"match": {"logLevel":"TRACE,DEBUG,INFO,WARN,ERROR"}});
+				}
+
 				$("#pi-text").val(params.procInstId?decodeURIComponent(params.procInstId):"");
 				$("#worker-id-text").val(params.workerId?decodeURIComponent(params.workerId):"");
 				$("#search-text").val(params.search?decodeURIComponent(params.search):"");

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -226,7 +226,6 @@
 					url: "/${base}/rest/logs/logs/get",
 					data: "source=" + encodeURIComponent(JSON.stringify(esReq)),
 					type: "GET",
-					contentType: "application/json",
 					async: false,
 					success: function (data) {
 						latestScrollId = data._scroll_id;

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -238,7 +238,8 @@
 				esReq = esReq.replace(/"/g, "%22");
 
 				$.ajax({
-					url: "/${base}/rest/logs/get/noScroll?source=" + esReq,
+					url: "/${base}/rest/logs/get/noScroll",
+					data: esReq,
 					type: "GET",
 					async: false,
 					success: function (ajaxData) {

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -631,6 +631,9 @@
 							data-date-format="yyyy-mm-dd"size="16"type="text">
 					</div>
 				</div>
+				<div id="filters-div-row" style="justify-content: flex-end !important; margin-top: 15px;">
+					<a id="filter-submit-btn" class="btn btn-info pull-right" href="#">Filter</a>
+				</div>
 			</div>
 			<div id="filter-btn-refresh-flexbox">
 				<div id="filters-btn"class="btn btn-warning"><span class="glyphicon glyphicon-filter">

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -86,6 +86,9 @@
 				if(params.search  !== undefined && params.search !== null){
 					esReq.query.bool.must.push({"query_string":{"fields":["msgBody"],"query":decodeURIComponent(params.search)}});
 				}
+				if (params.workerId !== undefined && params.workerId !== null) {
+					esReq.query.bool.must.push({"match":{"cwsWorkerId":params.workerId}});
+				}
 		
 				var startDate=params.startDate?decodeURIComponent(params.startDate):"";
 				var endDate=params.endDate?decodeURIComponent(params.endDate):"";
@@ -107,6 +110,7 @@
 					});
 				}
 				$("#pi-text").val(params.procInstId?decodeURIComponent(params.procInstId):"");
+				$("#worker-id-text").val(params.workerId?decodeURIComponent(params.workerId):"");
 				$("#search-text").val(params.search?decodeURIComponent(params.search):"");
 				$("#start-date").val(startDate);
 				$("#end-date").val(endDate);
@@ -449,6 +453,9 @@
 			if($("#pi-text").val()!=""){
 				params.procInstId=encodeURIComponent($("#pi-text").val());
 			}
+			if($("#worker-id-text").val()!=""){
+				params.workerId=encodeURIComponent($("#worker-id-text").val());
+			}
 			if($("#log-level-sel input:checked").length>0){
 				var lvl=[]
 				$("#log-level-sel input:checked").each(function(){
@@ -531,6 +538,8 @@
 						</select>
 						<h5>Process Instances</h5>
 						<input id="pi-text"type="text"class="form-control"placeholder="Instance ID...">
+						<h5>Worker ID</h5>
+						<input id="worker-id-text" type="text" class="form-control" placeholder="Worker ID...">
 					</div>
 					<div class="col-md-4">
 						<h5>Log Level</h5>
@@ -550,10 +559,10 @@
 					<div class="col-md-4">
 						<h5>Search by Keyword</h5>
 						<input id="search-text"id="filter-text"type="text"class="form-control"placeholder="Search..."/>
-						<span>Start Date:</span>
+						<h5>Start Date:</h5>
 						<input id="start-date"class="form-control"placeholder="yyyy-mm-dd"
         					data-date-format="yyyy-mm-dd"maxlength="10"type="text">
-						<span>End Date:</span>
+						<h5>End Date:</h5>
 						<input id="end-date"class="form-control"placeholder="yyyy-mm-dd"
         					data-date-format="yyyy-mm-dd"size="16"type="text">
 					</div>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -1,347 +1,185 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<title>CWS - Logs</title>
+	<title>CWS-Logs</title>
+
+	<!--Load JS Libraries-->
 
 	<script src="/${base}/js/jquery.min.js"></script>
-	<script src="/${base}/js/docs.min.js"></script>
-	<script src="/${base}/js/bootstrap-datepicker.min.js"></script>
+	<script src="/${base}/js/docs.min.js"></script><!--What is this?Are we using this currently?TODO:Investigate/remove-->
+	<script src="/${base}/js/moment.js"></script>
 	<script src="/${base}/js/bootstrap.min.js"></script>
-	<link href="/${base}/css/bootstrap.min.css" rel="stylesheet">
-	<link href="/${base}/css/bootstrap-datepicker.min.css" rel="stylesheet">
-	<!-- Custom styles for this template -->
-	<link href="/${base}/css/dashboard.css" rel="stylesheet">
+	<script src="/${base}/js/DataTables/datatables.js"></script>
+    <script src="/${base}/js/DataTablesDateFilter.js"></script>
+	<script src="/${base}/js/bootstrap-datepicker.min.js"></script>
+    <script src="/${base}/js/DataTables/dataTables.responsive.min.js"></script>
+    <script src="/${base}/js/DataTables/responsive.bootstrap.min.js"></script>
+
+	<!--Load CSS Stylesheets-->
+	<link href="/${base}/css/bootstrap.min.css"rel="stylesheet">
+	<link href="/${base}/css/bootstrap-datepicker.min.css"rel="stylesheet">
+	<link href="/${base}/js/DataTables/datatables.css"rel="stylesheet">
+	<link href="/${base}/css/dashboard.css"rel="stylesheet">
+	<link href="/${base}/css/logs.css"rel="stylesheet">
+
+	<!--JavaScript-->
 	<script>
 
 	//STATE PERSISTANCE CONSTS
-	const username = "username"; //temporary, hardcoded value for now
-	const cwsHostVar = "CWS_DASH_LOGS_CWSHOST-" + username;
-	const cwsWIDVar = "CWS_DASH_LOGS_CWSWID-" + username;
-	const logLevelVar = "CWS_DASH_LOGS_LOGLVL-" + username;
-	const threadNameVar = "CWS_DASH_LOGS_THN-" + username;
-	const processDefKeyVar = "CWS_DASH_LOGS_PDK-" + username;
-	const processInstIDVar = "CWS_DASH_LOGS_PID-" + username;
-	const refreshRateVar = "CWS_DASH_LOGS_REFRESH_RATE-" + username;
-	const refreshVar = "CWS_DASH_LOGS_REFRESH-" + username;
-	const qstringVar = "CWS_DASH_LOGS_QSTRING-" + username;
+	const username="username"; //temporary, hardcoded value for now
+	const refreshRateVar="CWS_DASH_LOGS_REFRESH_RATE-"+username;
+	const refreshVar="CWS_DASH_LOGS_REFRESH-"+username;
+	const qstringVar="CWS_DASH_LOGS_QSTRING-"+username;
 
 	// Global vars
 	var params;
-	var FETCH_COUNT = 200;
-	var htmlTableRows = [];
-	var renderFlag = 0;
+	var FETCH_COUNT=200;
+	var htmlTableRows=[];
+	var renderFlag=0;
 
-	var baseEsReq = {
-		"from": 0,
-		"size": FETCH_COUNT,
-		"query": { 
-			"bool": {
-				"must" :[]
+	var baseEsReq={
+		"from":0,
+		"size":FETCH_COUNT,
+		"query":{
+			"bool":{
+				"must":[]
 			}
 		},
-		"sort": { "@timestamp": { "order": "desc" } }
+		"sort":{
+			"@timestamp":{
+				"order":"desc"
+			}
+		}
 	};
 
-	//-------------------------
-	function renderRows(idx) {
-		if (renderFlag != 1) {
-			$("#log-div .ajax-spinner").hide();
-			return;
-		}
-		$('#logData').append(htmlTableRows[idx]);
-		setTimeout(function() {	
-			if (++idx < FETCH_COUNT) {
-				renderRows(idx);
-			}
-			else {
-				$("#log-div .ajax-spinner").hide();
-			}
-		}, 4);
-	}
-
-	//--------------------------
-	function loadDefaultLog() {
-		renderFlag = 0;
-		htmlTableRows = [];
-		var esReq = baseEsReq;
-		getLogData(esReq);
-	}
-	
 	//----------------------------
-	function loadLogsToTable() {
-		renderFlag = 0;
-		htmlTableRows = [];
-		var esReq = baseEsReq;
+	function fetchInitialLogs(){
+		renderFlag=0;
+		htmlTableRows=[];
+		var esReq=baseEsReq;
 
 		if(params.procDefKey){
-			esReq.query.bool.must.push({"match":{ "procDefKey" : params.procDefKey}});	
+			esReq.query.bool.must.push({"match":{"procDefKey":params.procDefKey}});
 		}
 		if(params.logLevel){
-			esReq.query.bool.must.push({"match":{"logLevel" : params.logLevel}});	
+			esReq.query.bool.must.push({"match":{"logLevel":params.logLevel}});
 		}
 		if(params.program){
-			esReq.query.bool.must.push({"match":{"program" : params.program}});
+			esReq.query.bool.must.push({"match":{"program":params.program}});
 		}
 		if(params.procInstId){
 			//esReq.query.bool.must.push({"match":{"procInstId" : decodeURIComponent(params.procInstId)}});
-			esReq.query.bool.must.push({"query_string":{"fields":["procInstId"],"query" : "\"" + decodeURIComponent(params.procInstId) + "\""}});
+			esReq.query.bool.must.push({"query_string":{"fields":["procInstId"],"query":"\""+decodeURIComponent(params.procInstId)+"\""}});
 		}
 		if(params.search){
-			esReq.query.bool.must.push({"query_string":{"fields":["msgBody"],"query" : decodeURIComponent(params.search)}});
+			esReq.query.bool.must.push({"query_string":{"fields":["msgBody"],"query":decodeURIComponent(params.search)}});
 		}
 
-		var startDate = params.startDate ? decodeURIComponent(params.startDate) : "";
-		var endDate = params.endDate ? decodeURIComponent(params.endDate) : "";
+		var startDate=params.startDate?decodeURIComponent(params.startDate):"";
+		var endDate=params.endDate?decodeURIComponent(params.endDate):"";
 
-		if(startDate != ""){
+		if(startDate!=""){
 			//esReq.query.range["@timestamp"].gte = startDate;
 			esReq.query.bool.must.push({"range":{"@timestamp":{"gte":startDate}}});
 		}
-		if(endDate != ""){
+		if(endDate!=""){
 			//esReq.query.range["@timestamp"].lte = endDate;
 			esReq.query.bool.must.push({"range":{"@timestamp":{"lte":endDate}}});
 		}
-		
-		$("#pd-select").val(params.procDefKey || "def");
+
+		$("#pd-select").val(params.procDefKey||"def");
 		//$("#level-select").val(params.logLevel || "def");
-		if (params.logLevel) {
+		if(params.logLevel){
 			params.logLevel.split(',').forEach(function(lvl){
-				$("#log-level-sel input[value='"+lvl+"']").prop("checked", true);
+				$("#log-level-sel input[value='"+lvl+"']").prop("checked",true);
 			});
 		}
-		$("#pi-text").val(params.procInstId ? decodeURIComponent(params.procInstId) : "");
-		$("#search-text").val(params.search ? decodeURIComponent(params.search) : "");
-		$("#start-date").val( startDate );
-		$("#end-date").val( endDate );
+		$("#pi-text").val(params.procInstId?decodeURIComponent(params.procInstId):"");
+		$("#search-text").val(params.search?decodeURIComponent(params.search):"");
+		$("#start-date").val(startDate);
+		$("#end-date").val(endDate);
 
 		getLogData(esReq);
 	}
 
-	//----------------------------
-	function getLogData(esReq) {
-		//
-		// GET LOGS DATA FROM BACKEND
-		//
-		$.ajax({
-			url: "/${base}/rest/logs/get?source="+encodeURIComponent(JSON.stringify(esReq)),
-			success: function(data) {
-				if (data.hits) {
-					var theLogData = data.hits.hits;
-					
-					if(theLogData.length > 0) {
-						$("#resultCount").html("<h3>Showing <b>" + theLogData.length + "</b> most recent matching rows</h3>");
-						
-						for(var i in theLogData) {
-							var logDataSource = theLogData[i]._source;
-							var row = "<tr";
-							var ll = '';
-							if (logDataSource.logLevel) {
-								ll = logDataSource.logLevel.trim();
-								if     ( ll == 'ERROR' ) { row += " class='danger'";  }
-								else if( ll == 'WARN' )  { row += " class='warning'"; }
-								else if( ll == 'DEBUG' ) { row += " class='debug'";   }
-							}
-							
-							row += ">"+
-								"<td>"+ logDataSource["@timestamp"] + "</td>"+
-								"<td class='"+ ( $("#cwshost-chkbox").prop("checked") ? '' : 'collapse' )+"'>"+ (logDataSource.cwsHost || '') + "</td>"+
-								"<td class='"+ ( $("#cwswid-chkbox").prop("checked") ? '' : 'collapse' )+"'>"+ (logDataSource.cwsWorkerId || '')+ "</td>"+
-								"<td class='"+ ( $("#loglvl-chkbox").prop("checked") ? '' : 'collapse' )+"'>"+ ll + "</td>"+
-								"<td class='"+ ( $("#thn-chkbox").prop("checked") ? '' : 'collapse' )+"'>"+ logDataSource.threadName + "</td>"+
-								"<td class='"+ ( $("#pdk-chkbox").prop("checked") ? '' : 'collapse' )+"'>"+ (logDataSource.procDefKey || '') + "</td>"+
-								"<td class='"+ ( $("#pid-chkbox").prop("checked") ? '' : 'collapse' )+"'>"+ (logDataSource.procInstId || '')+ "</td>"+
-								"<td><p>" + logDataSource.msgBody.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/\n/g, "<br/>") + "</p></td>"+
-								"</tr>";
-							
-							htmlTableRows.push(row);
-							
-						} // end for each theLogData
-						
-						renderFlag = 1;
-						renderRows(0);
-					}
-					else {
-						$('#logData').append("<tr><td colspan='5' class='no-results'><p>No results found</p></td></tr>");
-						$("#log-div .ajax-spinner").hide();
-					}
-				} // end if (data.hits)
-			},
-			error: function() {
-				$("#log-div .ajax-spinner").hide();
-				alert("Error filtering the log.");
-			}
-		});
+	$(document).ready(function(){
+
+	// DISPLAY MESSAGE AT TOP OF PAGE
+	//
+	if($("#statusMessageDiv:contains('ERROR:')").length>=1){
+		$("#statusMessageDiv").css("color","red");
+	} else if($("#statusMessageDiv h2").text()!=""){
+		$("#statusMessageDiv").css("color","green");
+		if($('#statusMessageDiv').html().length>9){
+			$('#statusMessageDiv').fadeOut(5000,"linear");
+		}
 	}
 
-	$( document ).ready(function() {
+	$("#logData").DataTable();
 
-		//go through the local storage and set checkboxes accordingly
-		if (localStorage.getItem(cwsHostVar) === "1") {
-			collapseColumn(2);
-			$("#cwshost-chkbox").prop("checked", true);
-		}
-		if (localStorage.getItem(cwsWIDVar) === "1") {
-			collapseColumn(3);
-			$("#cwswid-chkbox").prop("checked", true);
-		}
-		if (localStorage.getItem(logLevelVar) === "1") {
-			collapseColumn(4);
-			$("#loglvl-chkbox").prop("checked", true);
-		}
-		if (localStorage.getItem(threadNameVar) === "1") {
-			collapseColumn(5);
-			$("#thn-chkbox").prop("checked", true);
-		}
-		if (localStorage.getItem(processDefKeyVar) === "1") {
-			collapseColumn(6);
-			$("#pdk-chkbox").prop("checked", true);
-		}
-		if (localStorage.getItem(processInstIDVar) === "1") {
-			collapseColumn(7);
-			$("#pid-chkbox").prop("checked", true);
-		}
+	if(localStorage.getItem(refreshRateVar)===null){
+		localStorage.setItem(refreshRateVar,"10000");
+	}
 
-		// DISPLAY MESSAGE AT TOP OF PAGE
-		//
-		if ($("#statusMessageDiv:contains('ERROR:')").length >= 1) {
-			$("#statusMessageDiv").css( "color", "red" );
-		}
-		else if($("#statusMessageDiv h2").text() != ""){
-			$("#statusMessageDiv").css( "color", "green" );
-			if ($('#statusMessageDiv').html().length > 9) {
-				$('#statusMessageDiv').fadeOut(5000, "linear");
-			}
-		}
-
-		if (localStorage.getItem(refreshRateVar) === null) {
-		localStorage.setItem(refreshRateVar, "10000");
-		}
-
-		$("#refresh-rate").val((parseInt(localStorage.getItem(refreshRateVar))/1000).toString());
+	$("#refresh-rate").val((parseInt(localStorage.getItem(refreshRateVar))/1000).toString());
 
 
+	if(localStorage.getItem(refreshVar)==="1"){
+		$("#refresh-checkbox").prop("checked",true);
+		refreshRate=parseInt(localStorage.getItem(refreshRateVar));
+		refID=setInterval(refreshLogs,refreshRate);
+	} else{
+		$("#refresh-checkbox").prop("checked",false);
+	}
 
-		if(localStorage.getItem(refreshVar) === "1") {
-			$("#refresh-checkbox").prop("checked", true);
-			refreshRate = parseInt(localStorage.getItem(refreshRateVar));
-			refID = setInterval(refreshLogs, refreshRate);
+	//get our current url
+	var currentUrl=window.location.href;
+	//get our local storage url
+	var localStorageUrl=localStorage.getItem(qstringVar);
+	//check if a cookie has been stored (indicating we can restore state)
+	if(localStorageUrl!=null){
+		//remove everything before ?
+		currentUrl=currentUrl.substring(currentUrl.indexOf("logs")+4);
+		//compare against what is in local storage
+		if(currentUrl!=localStorageUrl){
+			//if they are different, go to the one in local storage (essentially restoring from last time used)
+			window.location="/${base}/logs"+localStorageUrl;
 		}
-		else{
-			$("#refresh-checkbox").prop("checked", false);
-		}
+	}
 
-		//get our current url
-		var currentUrl = window.location.href;
-		//get our local storage url
-		var localStorageUrl = localStorage.getItem(qstringVar);
-		//check if a cookie has been stored (indicating we can restore state)
-		if(localStorageUrl != null) {
-			//remove everything before ?
-			currentUrl = currentUrl.substring(currentUrl.indexOf("logs")+4);
-			//compare against what is in local storage
-			if (currentUrl != localStorageUrl) {
-				//if they are different, go to the one in local storage (essentially restoring from last time used)
-				window.location="/${base}/logs" + localStorageUrl;
-			}
-		}
-		
-		//
-		// INITIAL LOG SET
-		//
-		$("#log-div .ajax-spinner").show();
-		
-		//GET query string values
-		params = getQueryString();
-		
-		if (params == null) {
-			loadDefaultLog();
-		}
-		else{
-			loadLogsToTable();
-		}
-		
-		$("#log-div .ajax-spinner").hide();
-		
+	//
+	// INITIAL LOG SET
+	//
+	$("#log-div .ajax-spinner").show();
+
+	//GET query string values
+	params=getQueryString();
+
+	if(params==null){
+		loadDefaultLog();
+	}
+	else{
+		loadLogsToTable();
+	}
+
+	$("#log-div .ajax-spinner").hide();
+
 	}); //END OF DOCUMENT.READY
-
-
-
 
 	</script>
 	
-	<!-- Just for debugging purposes. Don't actually copy this line! -->
+	<!--Just for debugging purposes.Don't actually copy this line! -->
 	<!--[if lt IE 9]><script src="../../assets/js/ie8-responsive-file-warning.js"></script><![endif]-->
 
-	<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+	<!--HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries-->
 	<!--[if lt IE 9]>
 		<script src="/${base}/js/html5shiv.js"></script>
 		<script src="/${base}/js/respond.min.js"></script>
 	<![endif]-->
 
-	<style type="text/css">
-	#filters-table td{
-		width:20%;
-	}
-	#pd-select{
-		width:90%;
-	}
-
-	#log-level-sel{
-		border:1px solid #ddd;
-		border-radius: 4px;
-		padding: 5px;
-	}
-	#log-level-sel input{
-		margin-right: 5px
-	}
-	#log-level-sel label{
-		cursor: pointer;
-		font-weight: normal;
-	}
-	#logData{
-		font-size:95%;
-	}
-	#logData tr th{
-		white-space: nowrap;
-	}
-	/* log level header*/
-	#logData tr th:nth-child(5){
-		padding-right: 25px;
-	}
-	#logData tr td{
-		line-height: 1;
-	}
-	#logData tr td:nth-child(8){
-		/*overflow: auto;*/
-		word-wrap: break-word;
-		word-break: break-all;
-		font-family: courier,consolas;
-		/*white-space: normal !important;*/
-	}
-
-	
-	tr.debug{color:#777;}
-
-	#sh-cols div{
-		display: inline-block;
-		border-right: 1px solid #eee;
-		padding: 4px 15px;
-	}
-	#sh-cols div input, #sh-cols div label{
-		margin-right:8px;
-		cursor: pointer;
-	}
-	#sh-cols div:last-child{
-		border:none;
-	}
-	#start-date,#end-date{width:90%;}
-	</style>
-
 </head>
 
 <body>
-
-
 <#include "navbar.ftl">
 
 <div class="container-fluid">
@@ -361,101 +199,74 @@
 						<select id="pd-select">
 							<option value="def">All Process Definitions</option>
 							<#list procDefs as pd>
-							<option value="${pd.key}">${pd.name}</option>
+								<option value="${pd.key}">${pd.name}</option>
 							</#list>
 						</select>
 					</div>
 					<div class="col-md-2">
 						<h5>Process Instances</h5>
-						<input id="pi-text" type="text" class="form-control" placeholder="Instance ID...">
+						<input id="pi-text"type="text"class="form-control"placeholder="Instance ID...">
 					</div>
 					<div class="col-md-3">
 						<h5>Log Level</h5>
 						<div id="log-level-sel">
-							<input type='checkbox' id='trace' value='TRACE' />
+							<input type='checkbox'id='trace'value='TRACE'/>
 							<label for='trace'>Trace</label><br/>
-							<input type="checkbox" id='debug' value="DEBUG" />
+							<input type="checkbox"id='debug'value="DEBUG"/>
 							<label for='debug'>Debug</label><br/>
-							<input type="checkbox" id='info' value="INFO" />
+							<input type="checkbox"id='info'value="INFO"/>
 							<label for='info'>Information</label><br/>
-							<input type="checkbox" id='warning' value="WARN" />
+							<input type="checkbox"id='warning'value="WARN"/>
 							<label for='warning'>Warning</label><br/>
-							<input type="checkbox" id='error' value="ERROR" />
+							<input type="checkbox"id='error'value="ERROR"/>
 							<label for='error'>Error</label><br/>
 						</div>
 					</div>
 					<div class="col-md-2">
 						<h5>Search by Keyword</h5>
-						<input id="search-text" id="filter-text" type="text" class="form-control" placeholder="Search..." />
+						<input id="search-text"id="filter-text"type="text"class="form-control"placeholder="Search..."/>
 					</div>
 					<div class="col-md-3">
 						<span>Start Date:</span>
-						<input id="start-date" class="form-control" placeholder="yyyy-mm-dd"
-						data-date-format="yyyy-mm-dd" maxlength="10" type="text">
+						<input id="start-date"class="form-control"placeholder="yyyy-mm-dd"
+        data-date-format="yyyy-mm-dd"maxlength="10"type="text">
 					</div>
 					<div class="col-md-3">
 						<span>End Date:</span>
-						<input id="end-date" class="form-control" placeholder="yyyy-mm-dd"
-						data-date-format="yyyy-mm-dd" size="16" type="text">
+						<input id="end-date"class="form-control"placeholder="yyyy-mm-dd"
+        data-date-format="yyyy-mm-dd"size="16"type="text">
 					</div>
 
 					<div class="col-md-12">
-						<a id="filter-submit-btn" class="btn btn-info pull-right" href="#">Filter</a>
+						<a id="filter-submit-btn"class="btn btn-info pull-right"href="#">Filter</a>
 					</div>
 			</div>
-			<div id="filters-btn" class="btn btn-warning"><span class="glyphicon glyphicon-filter">
-				</span>&nbsp;Filters &nbsp;<span id="filter-arrow" class="glyphicon glyphicon-chevron-up"></span>
+			<div id="filters-btn"class="btn btn-warning"><span class="glyphicon glyphicon-filter">
+				</span>&nbsp;Filters&nbsp;<span id="filter-arrow"class="glyphicon glyphicon-chevron-up"></span>
 			</div>
-			<div style="margin:30px 0px;" class="pull-right">
-				<input type="checkbox" id="refresh-checkbox" />&nbsp;
+			<div style="margin:30px 0px;"class="pull-right">
+				<input type="checkbox"id="refresh-checkbox"/>&nbsp;
 				<label for='refresh-checkbox'>Refresh the logs every</label>&nbsp;
 				<select id="refresh-rate">
-					<option value="10">10 seconds</option>
-					<option value="5">5 seconds</option>
-					<option value="3">3 seconds</option>
-					<option value="1">1 second</option>
+					<option value="10">10seconds</option>
+					<option value="5">5seconds</option>
+					<option value="3">3seconds</option>
+					<option value="1">1second</option>
 				</select>
 			</div>
 			<div id="resultCount"></div>
-			<div id="sh-cols">
-				<div>Show/Hide Additional Columns:</div>
-				<div>
-					<input type="checkbox" id="cwshost-chkbox" />
-					<label for="cwshost-chkbox">CWS Host</label>
-				</div>
-				<div>
-					<input type="checkbox" id="cwswid-chkbox" />
-					<label for="cwswid-chkbox">CWS Worker ID</label>
-				</div>
-				<div>
-					<input type="checkbox" id="loglvl-chkbox" />
-					<label for="loglvl-chkbox">Log Level</label>
-				</div>
-				<div>
-					<input type="checkbox" id="thn-chkbox" />
-					<label for="thn-chkbox">Thread Name</label>
-				</div>
-				<div>
-					<input type="checkbox" id="pdk-chkbox" />
-					<label for="pdk-chkbox">Process Definition Key</label>
-				</div>
-				<div>
-					<input type="checkbox" id="pid-chkbox" />
-					<label for="pid-chkbox">Process Instance ID</label>
-				</div>
-			</div>
 			
 			<div id="log-div">
 				<div class="ajax-spinner"></div>
-				<table id="logData" class="table table-striped table-bordered sortable">
+				<table id="logData"class="table table-striped table-bordered sortable"style="width:100%;">
 					<tr>
-						<th class="sort" style="width: 190px">Time Stamp</th>
-						<th class="collapse">CWS Host</th>
-						<th class="collapse">CWS Worker ID</th>
-						<th class="sort collapse">Log Level</th>
-						<th class="collapse">Thread Name</th>
-						<th class="collapse">Proc Def Key</th>
-						<th class="collapse">Proc Inst ID</th>
+						<th>Time Stamp</th>
+						<th>CWS Host</th>
+						<th>CWS Worker ID</th>
+						<th>Log Level</th>
+						<th>Thread Name</th>
+						<th>Proc Def Key</th>
+						<th>Proc Inst ID</th>
 						<th>Message</th>
 					</tr>
 				</table>
@@ -464,7 +275,7 @@
 	</div>
 </div>
 
-<div class="modal fade" id="ajax-error-modal" role="dialog" data-backdrop="static" data-keyboard="false">
+<div class="modal fade"id="ajax-error-modal"role="dialog"data-backdrop="static"data-keyboard="false">
 	<div class="modal-dialog">
 		<div class="modal-content">
 			<div class="modal-header">
@@ -472,88 +283,85 @@
 			</div>
 
 			<div class="modal-body">
-				<p>There was an error sending an AJAX call to CWS. Please make sure that CWS is up and running.</p>
+				<p>There was an error sending an AJAX call to CWS.Please make sure that CWS is up and running.</p>
 			</div>
 
 			<div class="modal-footer">
-				<button type="button" class="btn btn-primary" data-dismiss="modal">Dismiss</button>
+				<button type="button"class="btn btn-primary"data-dismiss="modal">Dismiss</button>
 			</div>
-		</div> <!-- modal-content -->
-	</div> <!-- modal-dialog -->
-</div> <!-- .modal .fade -->
+		</div><!--modal-content-->
+	</div><!--modal-dialog-->
+</div><!--.modal.fade-->
 
 
-<script type="text/javascript" src="/${base}/js/cws.js"></script>
+<script type="text/javascript"src="/${base}/js/cws.js"></script>
 <script type="text/javascript">
-
 	$("#filters-btn").click(function(){
 		if($("#filters-div").is(":visible"))
 			$("#filter-arrow").removeClass("glyphicon-chevron-up").addClass("glyphicon-chevron-down");
 		else
 			$("#filter-arrow").removeClass("glyphicon-chevron-down").addClass("glyphicon-chevron-up");
-		
-		$("#filters-div").slideToggle();
 
+		$("#filters-div").slideToggle();
 	});
 
-	function getFilterQString() {
-		var params = {};
-		if($("#pd-select").val() != "def"){
-			params.procDefKey = $("#pd-select").val();
+	function getFilterQString(){
+		var params={};
+		if($("#pd-select").val()!="def"){
+			params.procDefKey=$("#pd-select").val();
 		}
-		if($("#pi-text").val() != ""){
-			params.procInstId = encodeURIComponent($("#pi-text").val()); 
+		if($("#pi-text").val()!=""){
+			params.procInstId=encodeURIComponent($("#pi-text").val());
 		}
-		if($("#log-level-sel input:checked").length > 0){
-			var lvl = []
+		if($("#log-level-sel input:checked").length>0){
+			var lvl=[]
 			$("#log-level-sel input:checked").each(function(){
 				lvl.push($(this).val());
 			});
-
-			params.logLevel = lvl.toString();
+			params.logLevel=lvl.toString();
 		}
-		if($("#search-text").val() != ""){
-			params.search = encodeURIComponent($("#search-text").val());
+		if($("#search-text").val()!=""){
+			params.search=encodeURIComponent($("#search-text").val());
 		}
-		if($("#start-date").val() != ""){
-			params.startDate = encodeURIComponent($("#start-date").val());
+		if($("#start-date").val()!=""){
+			params.startDate=encodeURIComponent($("#start-date").val());
 		}
-		if($("#end-date").val() != ""){
-			params.endDate = encodeURIComponent($("#end-date").val());
+		if($("#end-date").val()!=""){
+			params.endDate=encodeURIComponent($("#end-date").val());
 		}
-		var qstring = "?";
+		var qstring="?";
 
 		for(p in params){
-			qstring += p+"="+params[p]+"&";
+			qstring+=p+"="+params[p]+"&";
 		}
-		qstring = qstring.substring(0,qstring.length-1);
-		localStorage.setItem(qstringVar, qstring);
+		qstring=qstring.substring(0,qstring.length-1);
+		localStorage.setItem(qstringVar,qstring);
 		//console.log(encodeURI(qstring));
 		return qstring;
 	}
 
 	$("#filter-submit-btn").click(function(e){
 		e.preventDefault();
-		window.location="/${base}/logs" + getFilterQString();
+		window.location="/${base}/logs"+getFilterQString();
 	});
 
-	$("#filter-submit-btn").on("contextmenu", function(e){
-			$(this).attr("href", "/${base}/logs" + getFilterQString(false));
-		});
+	$("#filter-submit-btn").on("contextmenu",function(e){
+		$(this).attr("href","/${base}/logs"+getFilterQString(false));
+	});
 
-	var today = new Date();
-	var todayDate = today.getDate() + "/" + today.getMonth() + "/" + today.getFullYear() ;
+	var today=new Date();
+	var todayDate=today.getDate()+"/"+today.getMonth()+"/"+today.getFullYear();
 	//$("#start-date").attr("value", todayDate);
 
 	$("#start-date").datepicker({
 		orientation:'left top',
-		todayBtn: 'true',
+		todayBtn:'true',
 		todayHighlight:true
 	});
 
 	$("#end-date").datepicker({
 		orientation:'left top',
-		todayBtn: 'true',
+		todayBtn:'true',
 		todayHighlight:true
 	});
 
@@ -563,109 +371,24 @@
 	var refID;
 	$("#refresh-checkbox").click(function(){
 		if($(this).prop("checked")){
-			localStorage.setItem(refreshVar, "1");
-			refreshRate = parseInt(localStorage.getItem(refreshRateVar));
+			localStorage.setItem(refreshVar,"1");
+			refreshRate=parseInt(localStorage.getItem(refreshRateVar));
 			refreshLogs();
-			refID = setInterval(refreshLogs, refreshRate);
-		}
-		else{
-			localStorage.setItem(refreshVar, "0");
+			refID=setInterval(refreshLogs,refreshRate);
+		} else {
+			localStorage.setItem(refreshVar,"0");
 			clearInterval(refID);
 		}
 	});
 
-	$("#refresh-rate").on('change', function(){
-		refreshRate = parseInt($(this).val()) * 1000;
-		localStorage.setItem(refreshRateVar, refreshRate.toString());
+	$("#refresh-rate").on('change',function(){
+		refreshRate=parseInt($(this).val())*1000;
+		localStorage.setItem(refreshRateVar,refreshRate.toString());
 		if($("#refresh-checkbox").prop("checked")){
 			clearInterval(refID);
-			refID = setInterval(refreshLogs, refreshRate);
+			refID=setInterval(refreshLogs,refreshRate);
 		}
 	});
-
-	function refreshLogs(){
-		var logDataTableHeaders = $("#logData").html().substring(0, $("#logData").html().indexOf("</tr>")+5).split("<th ");
-		logDataTableHeaders.shift();
-		logDataTableHeaders.shift();
-		for (i = 0; i < logDataTableHeaders.length; i++) {
-			pos = logDataTableHeaders[i].indexOf(`=\"`) + 2;
-			logDataTableHeaders[i] = logDataTableHeaders[i].substring(pos, logDataTableHeaders[i].indexOf(`\">`, pos));
-		}
-
-		var logDataHeader = "<tr>"+
-				'<th class="sort" style="width: 190px">Time Stamp</th>'+
-				'<th class="'+logDataTableHeaders[0]+'">CWS Host</th>'+
-				'<th class="'+logDataTableHeaders[1]+'">CWS Worker ID</th>'+
-				'<th class="'+logDataTableHeaders[2]+'">Log Level</th>'+
-				'<th class="'+logDataTableHeaders[3]+'">Thread Name</th>'+
-				'<th class="'+logDataTableHeaders[4]+'">Proc Def Key</th>'+
-				'<th class="'+logDataTableHeaders[5]+'">Proc Inst ID</th>'+
-				'<th>Message</th>'+
-			"</tr>";
-
-		$(".ajax-spinner").show();
-
-		// CLEAR OUT LOG DATA TABLE
-		//
-		$("#logData").html(logDataHeader);
-
-		if (params == null) {
-			loadDefaultLog();
-		}
-		else {
-			loadLogsToTable();
-		}
-
-		setTimeout(function(){
-			$(".ajax-spinner").hide();
-		},500);
-	}
-
-	$("#sh-cols div input").click(function(){
-		switch ($(this).attr('id') ){
-			case 'cwshost-chkbox':
-				toggleLocalStorage(cwsHostVar);
-				collapseColumn(2);
-				break;
-			case 'cwswid-chkbox':
-				toggleLocalStorage(cwsWIDVar);
-				collapseColumn(3);
-				break;
-			case 'loglvl-chkbox':
-				toggleLocalStorage(logLevelVar);
-				collapseColumn(4);
-				break;
-			case 'thn-chkbox':
-				toggleLocalStorage(threadNameVar);
-				collapseColumn(5);
-				break;
-			case 'pdk-chkbox':
-				toggleLocalStorage(processDefKeyVar);
-				collapseColumn(6);
-				break;
-			case 'pid-chkbox':
-				toggleLocalStorage(processInstIDVar);
-				collapseColumn(7);
-				break;
-
-			default:break;
-		}
-	});
-
-function toggleLocalStorage(key) {
-	if (localStorage.getItem(key) == null) {
-		localStorage.setItem(key, "1");
-	} else if (localStorage.getItem(key) == "1") {
-		localStorage.setItem(key, "0");
-	} else {
-		localStorage.setItem(key, "1");
-	}
-}
-
-function collapseColumn(nth){
-	$("#logData tr th:nth-child("+nth+")").toggleClass('collapse');
-	$("#logData tr td:nth-child("+nth+")").toggleClass('collapse');
-}
 </script>
 
 </body>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -545,30 +545,31 @@
 						<input id="search-text"id="filter-text"type="text"class="form-control"placeholder="Search..."/>
 						<span>Start Date:</span>
 						<input id="start-date"class="form-control"placeholder="yyyy-mm-dd"
-        data-date-format="yyyy-mm-dd"maxlength="10"type="text">
+        					data-date-format="yyyy-mm-dd"maxlength="10"type="text">
 						<span>End Date:</span>
 						<input id="end-date"class="form-control"placeholder="yyyy-mm-dd"
-        data-date-format="yyyy-mm-dd"size="16"type="text">
+        					data-date-format="yyyy-mm-dd"size="16"type="text">
 					</div>
 
-					<div class="col-md-12">
+					<div class="col-md-12" style="margin-top: 15px;">
 						<a id="filter-submit-btn"class="btn btn-info pull-right"href="#">Filter</a>
 					</div>
 			</div>
-			<div id="filters-btn"class="btn btn-warning"><span class="glyphicon glyphicon-filter">
-				</span>&nbsp;Filters&nbsp;<span id="filter-arrow"class="glyphicon glyphicon-chevron-up"></span>
+			<div id="filter-btn-refresh-flexbox">
+				<div id="filters-btn"class="btn btn-warning"><span class="glyphicon glyphicon-filter">
+					</span>&nbsp;Filters&nbsp;<span id="filter-arrow"class="glyphicon glyphicon-chevron-up"></span>
+				</div>
+				<div style="margin:30px 15px;"class="pull-right">
+					<input type="checkbox"id="refresh-checkbox"/>&nbsp;
+					<label for='refresh-checkbox'>Refresh the logs every</label>&nbsp;
+					<select id="refresh-rate">
+						<option value="10">10 seconds</option>
+						<option value="5">5 seconds</option>
+						<option value="3">3 seconds</option>
+						<option value="1">1 second</option>
+					</select>
+				</div>
 			</div>
-			<div style="margin:30px 0px;"class="pull-right">
-				<input type="checkbox"id="refresh-checkbox"/>&nbsp;
-				<label for='refresh-checkbox'>Refresh the logs every</label>&nbsp;
-				<select id="refresh-rate">
-					<option value="10">10seconds</option>
-					<option value="5">5seconds</option>
-					<option value="3">3seconds</option>
-					<option value="1">1second</option>
-				</select>
-			</div>
-			<div id="resultCount"></div>
 			
 			<div id="log-div">
 				<div class="ajax-spinner"></div>

--- a/install/cws-ui/logs.ftl
+++ b/install/cws-ui/logs.ftl
@@ -148,6 +148,7 @@
 				}
 			},
 			deferRender: true,
+			stateSave: true,
 			scroller: {
 				boundaryScale: 0.50,
 				displayBuffer: 20,
@@ -225,11 +226,11 @@
 				var returnData;
 				var fetchError = "";
 
-				console.error("DATA: " + JSON.stringify(data));
-				console.error("ESREQ: " + JSON.stringify(esReq));
+				//console.error("DATA: " + JSON.stringify(data));
+				//console.error("ESREQ: " + JSON.stringify(esReq));
 
-				console.log("STRINGIFIED: " + JSON.stringify(esReq));
-				console.log("ENCODED: " + encodeURIComponent(JSON.stringify(esReq)));
+				//console.log("STRINGIFIED: " + JSON.stringify(esReq));
+				//console.log("ENCODED: " + encodeURIComponent(JSON.stringify(esReq)));
 
 				esReq = JSON.stringify(esReq);
 				esReq = encodeURIComponent(esReq);
@@ -242,7 +243,7 @@
 					async: false,
 					success: function (ajaxData) {
 						returnData = ajaxData;
-						console.error("RETURN DATA: " + JSON.stringify(returnData));
+						//console.error("RETURN DATA: " + JSON.stringify(returnData));
 	
 						//we should have our data now. We need to format it for the table
 						var formattedData = [];
@@ -306,7 +307,7 @@
 							"data": formattedData,
 							"error": fetchError
 						}
-						console.error("RETURN OBJ: " + JSON.stringify(returnObj));
+						//console.error("RETURN OBJ: " + JSON.stringify(returnObj));
 						callback(returnObj);
 					},
 					error: function (jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
This PR updates the Logs page to utilize Datatables (similar to Processes, History, Workers, Deployments, etc.)

This PR adds:

- Users can now search by Worker ID on the logs page. 
<img width="444" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/73c5e768-4ae4-4f03-87e8-d01aa0e98592">

- The table on the logs page is no longer limited to 200 lines and is now implemented using DataTables. This allows for native column visibility options and scrolling which automatically fetches more data as the user scrolls. DataTables is set to not render the data unless it is visible allowing the page to maintain high levels of performance. 
<img width="518" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/ff701a93-046c-4dff-a326-4175718b9f9e">

<img width="1350" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/0b20997a-afce-41b6-9285-6c398e7c3541">

- Updated the "Refresh the logs every x seconds" feature to avoid columns appearing and disappearing randomly on refresh. 

- Worker ID & Process Instance ID filter boxes now have autocomplete: 
<img width="366" alt="image" src="https://github.com/NASA-AMMOS/common-workflow-service/assets/74369489/9d8c7040-a42d-4511-994e-c78e31c340a8">
