### PR TITLE
Update dependencies to patch CVEs (Dependabot)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 		<!-- <boon.version>0.12</boon.version> -->
 		<camunda.version>7.19.0</camunda.version>
 		<camunda-spin.version>1.9.0</camunda-spin.version>
-		<commons-compress.version>1.20</commons-compress.version>
+		<commons-compress.version>1.21</commons-compress.version>
 		<commons-configuration.version>1.10</commons-configuration.version>
 		<commons-exec.version>1.3</commons-exec.version>
 		<commons-fileupload.version>1.3.3</commons-fileupload.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<commons-configuration.version>1.10</commons-configuration.version>
 		<commons-exec.version>1.3</commons-exec.version>
 		<commons-fileupload.version>1.3.3</commons-fileupload.version>
-		<commons-io.version>2.4</commons-io.version>
+		<commons-io.version>2.7</commons-io.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<commons-email.version>1.3.2</commons-email.version>
 		<cws.version>${project.version}</cws.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		<fst.version>1.55</fst.version> <!--  USE 1.35 for Java6, 1.55 for Java7 -->
 		<grizzly-http-server.version>2.3.11</grizzly-http-server.version>
 		<gson.version>2.8.9</gson.version>
-		<h2.version>1.2.132</h2.version>
+		<h2.version>2.2.220</h2.version>
 		<!-- <httpclient.version>4.3</httpclient.version> -->
 		<jacoco.version>0.8.2</jacoco.version>
 		<java.version>11</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 		<commons-compress.version>1.21</commons-compress.version>
 		<commons-configuration.version>1.10</commons-configuration.version>
 		<commons-exec.version>1.3</commons-exec.version>
-		<commons-fileupload.version>1.3.3</commons-fileupload.version>
+		<commons-fileupload.version>1.5</commons-fileupload.version>
 		<commons-io.version>2.7</commons-io.version>
 		<commons-lang.version>2.6</commons-lang.version>
 		<commons-email.version>1.5</commons-email.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<mockito.version>4.3.1</mockito.version>
 		<mybatis.version>3.5.3</mybatis.version>
-		<mysql-connector.version>8.0.16</mysql-connector.version>
+		<mysql-connector.version>8.0.28</mysql-connector.version>
 		<hikaricp.version>4.0.3</hikaricp.version>
 		<phantomjsdriver.version>1.0.4</phantomjsdriver.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 		<maven-failsafe-plugin.version>2.22.0</maven-failsafe-plugin.version>
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<mockito.version>4.3.1</mockito.version>
-		<mybatis.version>3.5.3</mybatis.version>
+		<mybatis.version>3.5.6</mybatis.version>
 		<mysql-connector.version>8.0.28</mysql-connector.version>
 		<hikaricp.version>4.0.3</hikaricp.version>
 		<phantomjsdriver.version>1.0.4</phantomjsdriver.version>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
 		<commons-fileupload.version>1.3.3</commons-fileupload.version>
 		<commons-io.version>2.7</commons-io.version>
 		<commons-lang.version>2.6</commons-lang.version>
-		<commons-email.version>1.3.2</commons-email.version>
+		<commons-email.version>1.5</commons-email.version>
 		<cws.version>${project.version}</cws.version>
 		<cws.core.version>${cws.version}</cws.core.version>
 		<cws.tasks.version>${cws.version}</cws.tasks.version>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 		<jms.version>1.1</jms.version>
 		<joda-time.version>2.1</joda-time.version>
 		<junit.version>4.13.1</junit.version>
-		<jython-standalone.version>2.7.1b3</jython-standalone.version>
+		<jython-standalone.version>2.7.2b3</jython-standalone.version>
 		<mariadb-java-client.version>2.7.2</mariadb-java-client.version>
 
 		<maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>


### PR DESCRIPTION
This PR updates the following:

- Updates H2 Database to version 2.2.220
- Updates Apache Commons IO to version 2.7
- Updates MySQL Connectors Java to version 8.0.28
- Updates Jython to version 2.7.2b3
- Updates MyBatis to version 3.5.6
- Updates Apache Commons Compress to version 1.21
- Updates Apache Commons Email to version 1.5
- Updates Apache Commons FileUpload to version 1.5
