### PR TITLE
IDS-9540: Add debug log for WorkerService remainder bug

### DIFF
--- a/cws-core/src/main/java/jpl/cws/core/db/SchedulerDbService.java
+++ b/cws-core/src/main/java/jpl/cws/core/db/SchedulerDbService.java
@@ -398,6 +398,13 @@ public class SchedulerDbService extends DbService implements InitializingBean {
         return jdbcTemplate.queryForObject(query, Integer.class);
     }
 
+    public List<Map<String, Object>> getProcDefKeyLatestCompleteInst(String procDefKey) {
+        return jdbcTemplate.queryForList(
+            "SELECT proc_inst_id, start_time, end_time FROM cws_proc_inst_status WHERE proc_def_key=? AND status='complete' ORDER BY start_time DESC LIMIT 1",
+            new Object[]{procDefKey}
+        );
+    }
+
 
     public String getProcDefKeyFromUuid(String uuid) {
         String query = "SELECT proc_def_key FROM cws_sched_worker_proc_inst " + "WHERE uuid='" + uuid + "'";

--- a/cws-engine-service/src/main/java/jpl/cws/engine/WorkerService.java
+++ b/cws-engine-service/src/main/java/jpl/cws/engine/WorkerService.java
@@ -756,6 +756,13 @@ public class WorkerService implements InitializingBean {
 					"(remainders = " + remainders +
 					", procMaxNumbers = " + workerMaxProcInstances.entrySet() +
 					", currentCounts = " + currentCounts + ")");
+
+				for (Entry<String,Integer> entry : remainders.entrySet()) {
+					List<Map<String, Object>> lastCompleteProcInst = schedulerDbService.getProcDefKeyLatestCompleteInst(entry.getKey().toString());
+					if (lastCompleteProcInst.size() > 0) {
+						log.debug("Last completed process instance for procDefKey '" + entry.getKey().toString() + "': " + lastCompleteProcInst);
+					}
+				}
 			}
 
 


### PR DESCRIPTION
* Add debug log for when job claim is blocked. When remainder is <= 0
    - debug log output for last successful instance of each procDefKey: process instance id, process start time, process end time
    
    
```
[localhost][localhost_548152836_1707430967718] Last completed process instance for procDefKey 'test_error_end_event': [{proc_inst_id=bae8d753-c6d1-11ee-b3df-167dda6ad765, start_time=2024-02-08 14:30:58.135, end_time=2024-02-08 14:30:58.19}]
```