### PR TITLE
IDS-10384: Encode CRLF in log output to prevent log injection (S5145)

### DIFF
--- a/cws-installer/src/main/resources/log4j2.properties
+++ b/cws-installer/src/main/resources/log4j2.properties
@@ -19,7 +19,7 @@ status = warn
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = INSTALLER: %d{ISO8601}{UTC} %-5p [%20.20t] %30.30c(%4.4L) - %m%n
+appender.console.layout.pattern = INSTALLER: %d{ISO8601}{UTC} %-5p [%20.20t] %30.30c(%4.4L) - %encode{%m}{CRLF}%n
 
 # configure loggers
 # Spring Framework

--- a/install/tomcat_lib/log4j2-tomcat.properties
+++ b/install/tomcat_lib/log4j2-tomcat.properties
@@ -16,7 +16,7 @@ appender.rolling.name = RollingFile
 appender.rolling.fileName = ${sys:catalina.base}/logs/cws.log
 appender.rolling.filePattern = ${sys:catalina.base}/logs/cws.%d{yyyy-MM-dd}.log
 appender.rolling.layout.type = PatternLayout
-appender.rolling.layout.pattern = %d{ISO8601}{UTC} %-5p [%20.20t] %30.30c(%4.4L) - %m%n
+appender.rolling.layout.pattern = %d{ISO8601}{UTC} %-5p [%20.20t] %30.30c(%4.4L) - %encode{%m}{CRLF}%n
 appender.rolling.policies.type = Policies
 appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 appender.rolling.policies.time.interval = 1
@@ -30,7 +30,7 @@ appender.artemis.name = ArtemisFile
 appender.artemis.fileName = ${sys:catalina.base}/logs/artemis.log
 appender.artemis.filePattern = ${sys:catalina.base}/logs/artemis.%d{yyyy-MM-dd}.log
 appender.artemis.layout.type = PatternLayout
-appender.artemis.layout.pattern = %d{ISO8601}{UTC} %-5p [%20.20t] %30.30c(%4.4L) - %m%n
+appender.artemis.layout.pattern = %d{ISO8601}{UTC} %-5p [%20.20t] %30.30c(%4.4L) - %encode{%m}{CRLF}%n
 appender.artemis.policies.type = Policies
 appender.artemis.policies.time.type = TimeBasedTriggeringPolicy
 appender.artemis.policies.time.interval = 1
@@ -49,7 +49,7 @@ appender.rolling.strategy.fileIndex = nomax
 appender.CONSOLE.type = Console
 appender.CONSOLE.name = STDOUT
 appender.CONSOLE.layout.type = PatternLayout
-appender.CONSOLE.layout.pattern = %d{ISO8601}{UTC} %-5p [%20.20t] %30.30c(%4.4L) - %m%n
+appender.CONSOLE.layout.pattern = %d{ISO8601}{UTC} %-5p [%20.20t] %30.30c(%4.4L) - %encode{%m}{CRLF}%n
 
 ## Configure which loggers log to which appenders
 


### PR DESCRIPTION
## Summary

SonarQube identified **17 Log Injection findings** (`javasecurity:S5145`, MINOR) across the codebase. Every one shares a **single root cause**: the Log4j2 `PatternLayout` used the raw `%m` message converter, which does not encode CR/LF characters. An authenticated user could therefore inject CRLF sequences into a user-controlled value (e.g. `uuid`, `procDefKey`, `beanName`, `workerId`, `urlString`, `processVariables`) and forge log lines.

Instead of sanitizing each of the ~17 call sites individually (brittle, leaves gaps, and rots as new log statements are added), this applies the **Log4j2-native remediation centrally**: wrap the message converter in `%encode{%m}{CRLF}` on every `PatternLayout`.

## Why this approach

- **Central & complete** — fixes every current *and future* log statement in one place, including sites SonarQube did not flag.
- **Native & safe** — `%encode{...}{CRLF}` encodes CR/LF only within the message body; auto-appended stack traces sit outside the wrapper and stay readable/multi-line.
- **Low risk** — config-only; no Java changes, no recompile. `monitorInterval = 30` reloads the Tomcat config live.
- **Supported** — `%encode{}{CRLF}` is the documented OWASP/SonarQube fix for S5145; fully supported in the bundled Log4j 2.25.x.

## Changes

| File | Appenders updated |
|------|-------------------|
| `install/tomcat_lib/log4j2-tomcat.properties` | `rolling`, `artemis`, `CONSOLE` |
| `cws-installer/src/main/resources/log4j2.properties` | `console` |

Each `... - %m%n` becomes `... - %encode{%m}{CRLF}%n`.

## SonarQube findings cleared (IDS-10384)

All 17 `javasecurity:S5145` findings, including:
`SchedulerDbService.java:500`, `SecurityService.java:124`, `SpringApplicationContext.java:74,78`, `WebUtils.java:83,180`, `RestService.java:523,542,854,1126,1568,1592,1605,1636`, `InitiatorsService.java:416`, `Scheduler.java:130,140`.

## Testing

- [ ] Smoke-test log output after deploy: confirm normal messages render, multi-line stack traces remain intact, and a value containing `\r\n` is encoded on a single line.
- [ ] Re-run SonarQube scan to confirm the 17 S5145 findings clear.

## Out of scope

The related SSRF finding (`javasecurity:S7044`, IDS-10385) is **not** addressed here — it is being dispositioned as an accepted risk (see ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)